### PR TITLE
Update UaSdk/Makefile to adapt library names, include paths to uasdk version 1.6

### DIFF
--- a/devOpcuaSup/UaSdk/Makefile
+++ b/devOpcuaSup/UaSdk/Makefile
@@ -27,8 +27,22 @@ opcua_SRCS += iocshIntegrationUaSdk.cpp
 DBD_INSTALLS += opcuaUaSdk.dbd
 DBD_INSTALLS += opcua.dbd
 
-UASDK_LIBS = uabase uaclient uapki uastack xmlparser
-USR_INCLUDES += $(foreach module, $(UASDK_LIBS), -I$(UASDK)/include/$(module))
+UASDK_LIBS_C   = uastack
+UASDK_LIBS_CPP = uabase uaclient uapki xmlparser
+
+# Include paths and libnames changed from version 1.5 to 1.6
+ifeq (-v1.6.,$(findstring -v1.6.,$(UASDK) ))
+  USR_INCLUDES += $(foreach module, $(UASDK_LIBS_C), -I$(UASDK)/include/$(module))
+  USR_INCLUDES += $(foreach module, $(UASDK_LIBS_CPP), -I$(UASDK)/include/$(module)cpp)
+  UASDK_LIBS += $(UASDK_LIBS_C) $(foreach module, $(UASDK_LIBS_CPP), $(module)cpp)
+else
+  ifeq (-v1.5.,$(findstring -v1.5.,$(UASDK) ))
+    UASDK_LIBS += $(UASDK_LIBS_C) $(UASDK_LIBS_CPP)
+    USR_INCLUDES += $(foreach module, $(UASDK_LIBS), -I$(UASDK)/include/$(module))
+  else
+    $(warning ERROR: Can't find supported version tag in UASDK=$(UASDK) )
+  endif
+endif
 
 ifeq ($(UASDK_DEPLOY_MODE),SYSTEM)
 USR_SYS_LIBS += $(UASDK_LIBS)


### PR DESCRIPTION
With the release of version 1.6 of the UnifiedAutomation sdk was a change of lib and includepath names.
E.g. uabase -> uabasecpp