### PR TITLE
Update README to make a note for the building option for UASDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ O.*/
 /QtC-*
 *.orig
 *.log
+
+envPaths

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ commercially available Unified Automation C++ Based OPC UA Client SDK.
   Use the `CONFIG_SITE.local` file in the module where the binary is created
   to set this option.
 
+* Since UASDK v1.6.3 has BUILD_SHARED_LIBS=OFF as default,
+  one should use ON via ```./buildSdk.sh -s ON```.
+
 ## Building the module
 
 This is a standard EPICS module.

--- a/devOpcuaSup/UaSdk/RULES_OPCUA
+++ b/devOpcuaSup/UaSdk/RULES_OPCUA
@@ -1,3 +1,4 @@
+# ; -*- mode: makefile;-*-
 #*************************************************************************
 # Copyright (c) 2018 ITER Organization.
 # This module is distributed subject to a Software License Agreement found
@@ -31,7 +32,7 @@ ifeq ($(UASDK_DEPLOY_MODE),SYSTEM)
 USR_SYS_LIBS += $(UASDK_LIBS)
 endif
 
-ifeq ($(UASDK_DEPLOY_MODE),PROVIDED)
+ifeq ($(UASDK_DEPLOY_MODE),$(filter $(UASDK_DEPLOY_MODE), PROVIDED INSTALL))
 define UA_template
   USR_LIBS += $(1)
   $(1)_DIR = $(UASDK_DIR)
@@ -54,10 +55,10 @@ ifeq ($(UASDK_DEPLOY_MODE),INSTALL)
 build: $(EXTLIB_INSTALLS)
 
 $(INSTALL_LIB)/$(LIB_PREFIX)%$(LIB_SUFFIX) : $(UASDK_DIR)/$(LIB_PREFIX)%$(LIB_SUFFIX)
-        $(ECHO) "Installing library $@ from Unified Automation SDK"
-        $(INSTALL) -d -m 444 $< $(@D)
+	$(ECHO) "Installing library $@ from Unified Automation SDK"
+	$(INSTALL) -d -m 444 $< $(@D)
 
 $(INSTALL_LIB)/$(SHRLIB_PREFIX)%$(SHRLIB_SUFFIX) : $(UASDK_DIR)/$(SHRLIB_PREFIX)%$(SHRLIB_SUFFIX)
-        $(ECHO) "Installing shared library $@ from Unified Automation SDK"
-        $(INSTALL) -d -m 555 $< $(@D)
+	$(ECHO) "Installing shared library $@ from Unified Automation SDK"
+	$(INSTALL) -d -m 555 $< $(@D)
 endif

--- a/devOpcuaSup/UaSdk/RULES_OPCUA
+++ b/devOpcuaSup/UaSdk/RULES_OPCUA
@@ -1,4 +1,3 @@
-# ; -*- mode: makefile;-*-
 #*************************************************************************
 # Copyright (c) 2018 ITER Organization.
 # This module is distributed subject to a Software License Agreement found


### PR DESCRIPTION
Hi Ralph,

   I added the mandatory option for shared libraries of the UASDK into README.md. 
   And added the envPaths into gitignore, and few issues on RULE_OPCUA when I selected 
   ```UASDK_DEPLOY_MODE = INSTALL```.

   Please check it and let me know. 

   Thanks,
   Han
