### PR TITLE
Remove the compiler gcc6.3.0 warning and note

### DIFF
--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -133,7 +133,7 @@ monitor (opcuaItemRecord *prec)
 long
 readValue (opcuaItemRecord *prec)
 {
-    long status;
+    long status=0;
 
     if (prec->pact)
         goto read;


### PR DESCRIPTION
Hi Ralph,

  This is a cosmetic thing, which I can contribute, which can remove the following lines with gcc 6.3.0. 

```
../devOpcuaSup/opcuaItemRecord.cpp: In function ‘long int {anonymous}::process(opcuaItemRecord*)’:
../devOpcuaSup/opcuaItemRecord.cpp:161:5: warning: ‘status’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (!status)
     ^~
../devOpcuaSup/opcuaItemRecord.cpp:136:10: note: ‘status’ was declared here
     long status;
```
  Please let me know what you think.

  Han
