### PR TITLE
Support for Google Test in EPICS build system (as a Sup)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ matrix:
   include:
 
   - env: BRBASE=7.0 UASDK=1.5.6
+    addons: { apt: { packages: ["libgtest-dev"] } }
 
   - env: BRBASE=3.15 UASDK=1.5.6
+    addons: { apt: { packages: ["libgtest-dev"] } }
 
   - env: BRBASE=7.0 UASDK=1.6.3 CMPLR=gcc-6
     dist: xenial
-    addons: { apt: { packages: ["g++-6"], sources: ["ubuntu-toolchain-r-test"] } }
+    addons: { apt: { packages: ["g++-6", "libgtest-dev"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - env: BRBASE=3.15 UASDK=1.6.3 CMPLR=gcc-6
     dist: xenial
-    addons: { apt: { packages: ["g++-6"], sources: ["ubuntu-toolchain-r-test"] } }
+    addons: { apt: { packages: ["g++-6", "libgtest-dev"], sources: ["ubuntu-toolchain-r-test"] } }

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -48,6 +48,9 @@ UASDK_DIR = $(UASDK)/lib
 UASDK_USE_CRYPTO = YES
 UASDK_USE_XMLPARSER = YES
 
+# Expect Google Test as system package
+GTEST_HOME = SYSTEM
+
 USR_CXXFLAGS_Linux += -std=c++11
 USR_CXXFLAGS += -DUSE_TYPED_RSET
 

--- a/gtestSup/CONFIG_GTEST
+++ b/gtestSup/CONFIG_GTEST
@@ -1,0 +1,8 @@
+# Pointer to the Google Test location
+#   <not set> = do not use gtest
+#   SYSTEM    = libraries and headers are in a system location
+#   <path>    = libraries and headers are under <path>
+
+GTEST_HOME = SYSTEM
+
+# Remember that Google Test needs C++11 to be activated

--- a/gtestSup/Makefile
+++ b/gtestSup/Makefile
@@ -1,0 +1,26 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+ifdef GTEST_HOME
+
+#==================================================
+# Build EPICS gtest_main library (uses TAP output)
+
+LIBRARY_HOST += epics_gtest_main
+epics_gtest_main_SRCS += gtest_main.cc
+
+CFG += RULES_GTEST
+CFG += CONFIG_GTEST
+
+endif
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/gtestSup/RULES_GTEST
+++ b/gtestSup/RULES_GTEST
@@ -1,0 +1,29 @@
+# Definitions for Google Test
+
+# GTEST_HOME - pointer to the Google Test location
+#   <not set> = do not use gtest
+#   SYSTEM    = libraries and headers are in a system location
+#   <path>    = libraries and headers are under <path>
+
+# A special version of gtest_main (that provides TAP output)
+# is provided by EPICS Base in library epics_gtest_main
+
+ifdef GTEST_HOME
+
+ifeq ($(GTEST_HOME),SYSTEM)
+define gtest_prod_template
+  $(1)_SYS_LIBS += gtest epics_gtest_main pthread
+endef
+else
+define gtest_prod_template
+  $(1)_SYS_LIBS += pthread
+  $(1)_LIBS += gtest epics_gtest_main
+  $(1)_INCLUDES += -I$(GTEST_HOME)/googletest/include
+endef
+gtest_DIR = $(GTEST_HOME)/googletest
+endif
+
+$(foreach testprod, $(GTESTPROD_HOST), $(eval $(call gtest_prod_template,$(testprod))))
+TESTPROD_HOST +=  $(GTESTPROD_HOST)
+
+endif

--- a/gtestSup/gtest_main.cc
+++ b/gtestSup/gtest_main.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) <2011> <Bruno P. Kinoshita - http://www.kinoshita.eti.br>.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "gtest/gtest.h"
+#include "tap.h"
+
+GTEST_API_ int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+
+  testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+
+  // Delete the default listener
+  delete listeners.Release(listeners.default_result_printer());
+  listeners.Append(new tap::TapListener());
+  return RUN_ALL_TESTS();
+}
+

--- a/gtestSup/tap.h
+++ b/gtestSup/tap.h
@@ -1,0 +1,262 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011 Bruno P. Kinoshita <http://www.kinoshita.eti.br>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Bruno P. Kinoshita <http://www.kinoshita.eti.br>
+ * @since 0.1
+ */
+
+#ifndef TAP_H_
+#define TAP_H_
+
+#include <cstdlib>
+#include <list>
+#include <iostream>
+#include <map>
+#include <fstream>
+#include <string>
+#include <algorithm>
+
+// Make printing to stdout the default
+// Ralph Lange 2019
+#ifdef GTEST_TAP_PRINT_TO_FILE
+#undef GTEST_TAP_PRINT_TO_STDOUT
+#else
+#define GTEST_TAP_PRINT_TO_STDOUT
+#endif
+
+namespace tap {
+
+// based on http://stackoverflow.com/a/7724536/831180
+std::string replace_all_copy(
+  std::string const& original,
+  std::string const& before,
+  std::string const& after
+) {
+  using namespace std;
+
+  if (before == after) return string(original);
+
+  string retval;
+  if (before.length() == after.length()) retval.reserve(original.size());
+
+  auto end = original.end();
+  auto current = original.begin();
+  auto next =
+    search(current, end, before.begin(), before.end());
+
+  while ( next != end ) {
+    retval.append( current, next );
+    retval.append( after );
+    current = next + before.size();
+    next = search(current, end, before.begin(), before.end());
+  }
+  retval.append( current, next );
+  return retval;
+}
+
+class TestResult {
+
+ private:
+  int number;
+  std::string status;
+  std::string name;
+  std::string comment;
+  bool skip;
+
+ public:
+  std::string getComment() const {
+    std::stringstream ss;
+    if (this->skip) {
+      ss << "# SKIP " << this->comment;
+    } else if (!this->comment.empty()) {
+      ss << "# " << this->comment;
+    }
+    return ss.str();
+  }
+
+  const std::string& getName() const {
+    return name;
+  }
+
+  int getNumber() const {
+    return number;
+  }
+
+  const std::string& getStatus() const {
+    return status;
+  }
+
+  bool getSkip() const {
+    return skip;
+  }
+
+  void setComment(const std::string& comment) {
+    this->comment = comment;
+  }
+
+  void setName(const std::string& name) {
+    this->name = name;
+  }
+
+  void setNumber(int number) {
+    this->number = number;
+  }
+
+  void setStatus(const std::string& status) {
+    this->status = status;
+  }
+
+  void setSkip(bool skip) {
+    this->skip = skip;
+  }
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << this->status << " " << this->number << " " << this->name;
+#ifdef GTEST_TAP_13_DIAGNOSTIC
+    std::string comment_text = this->getComment();
+    if (!comment_text.empty()) {
+      ss << std::endl
+       << "# Diagnostic" << std::endl
+       << "  ---" << std::endl
+       << "  " << replace_all_copy(this->getComment(), "\n", "\n  ");
+    }
+#endif
+    return ss.str();
+  }
+};
+
+class TestSet {
+
+ private:
+  std::list<TestResult> testResults;
+
+ public:
+  const std::list<TestResult>& getTestResults() const {
+    return testResults;
+  }
+
+  void addTestResult(TestResult& testResult) {
+    testResult.setNumber((this->getNumberOfTests() + 1));
+    this->testResults.push_back(testResult);
+  }
+
+  int getNumberOfTests() const {
+    return this->testResults.size();
+  }
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << "1.." << this->getNumberOfTests() << std::endl;
+    for (std::list<TestResult>::const_iterator ci = this->testResults.begin();
+	 ci != this->testResults.end(); ++ci) {
+      TestResult testResult = *ci;
+      ss << testResult.toString() << std::endl;
+    }
+    return ss.str();
+  }
+};
+
+class TapListener: public ::testing::EmptyTestEventListener {
+
+ private:
+  std::map<std::string, tap::TestSet> testCaseTestResultMap;
+
+  void addTapTestResult(const testing::TestInfo& testInfo) {
+    tap::TestResult tapResult;
+    tapResult.setName(testInfo.name());
+    tapResult.setSkip(!testInfo.should_run());
+
+    const testing::TestResult *testResult = testInfo.result();
+    int number = testResult->total_part_count();
+    if (testResult->HasFatalFailure()) {
+      tapResult.setStatus("Bail out!");
+    } else if (testResult->Failed()) {
+      tapResult.setStatus("not ok");
+      tapResult.setComment(testResult->GetTestPartResult(number-1).summary());
+    } else {
+      tapResult.setStatus("ok");
+    }
+
+    this->addNewOrUpdate(testInfo.test_case_name(), tapResult);
+  }
+
+  std::string getCommentOrDirective(const std::string& comment, bool skip) {
+    std::stringstream commentText;
+
+    if (skip) {
+      commentText << " # SKIP " << comment;
+    } else if (!comment.empty()) {
+      commentText << " # " << comment;
+    }
+
+    return commentText.str();
+  }
+
+  void addNewOrUpdate(const std::string& testCaseName, tap::TestResult testResult) {
+    std::map<std::string, tap::TestSet>::const_iterator ci =
+      this->testCaseTestResultMap.find(testCaseName);
+    if (ci != this->testCaseTestResultMap.end()) {
+      tap::TestSet testSet = ci->second;
+      testSet.addTestResult(testResult);
+      this->testCaseTestResultMap[testCaseName] = testSet;
+    } else {
+      tap::TestSet testSet;
+      testSet.addTestResult(testResult);
+      this->testCaseTestResultMap[testCaseName] = testSet;
+    }
+  }
+
+public:
+  virtual void OnTestEnd(const testing::TestInfo& testInfo) {
+    //printf("%s %d - %s\n", testInfo.result()->Passed() ? "ok" : "not ok", this->testNumber, testInfo.name());
+    this->addTapTestResult(testInfo);
+  }
+
+  virtual void OnTestProgramEnd(const testing::UnitTest& unit_test) {
+    //--- Write the count and the word.
+    std::map<std::string, tap::TestSet>::const_iterator ci;
+    for (ci = this->testCaseTestResultMap.begin();
+     ci != this->testCaseTestResultMap.end(); ++ci) {
+      const tap::TestSet& testSet = ci->second;
+#ifdef GTEST_TAP_PRINT_TO_STDOUT
+      std::cout << "TAP version 13" << std::endl;
+      std::cout << testSet.toString();
+#else
+      std::ofstream tapFile;
+      std::stringstream tapFileName;
+      if (const char* prefix = std::getenv("GTEST_TAP_FILENAME_PREFIX"))
+        tapFileName << prefix;
+      tapFileName << ci->first;
+      tapFileName << ".tap";
+      tapFile.open(tapFileName.str().c_str());
+      tapFile << testSet.toString();
+      tapFile.close();
+#endif
+    }
+  }
+};
+
+} // namespace tap
+
+#endif // TAP_H_


### PR DESCRIPTION
Adds the necessary files, configuration and rules to run Google Test executables inside the regular EPICS build system "make runtests" target.