### PR TITLE
Update exampleTop ServerInfo/States template files to be updated

### DIFF
--- a/exampleTop/TemplateDbSup/AnyServerDb/opcuaServerInfo.template
+++ b/exampleTop/TemplateDbSup/AnyServerDb/opcuaServerInfo.template
@@ -4,18 +4,18 @@
 # Macros:
 # P     device prefix
 # R     device suffix
-# SESS  session name
+# SUBS  subscription name
 
 # static information (always read when connecting)
 record(stringin, "$(P)$(R)ManufacturerName") {
   field(DTYP, "OPCUA")
-  field(INP, "@$(SESS) i=2263")
+  field(INP, "@$(SUBS) i=2263")
 }
 record(stringin, "$(P)$(R)ProductName") {
   field(DTYP, "OPCUA")
-  field(INP, "@$(SESS) i=2261")
+  field(INP, "@$(SUBS) i=2261")
 }
 record(stringin, "$(P)$(R)SoftwareVersion") {
   field(DTYP, "OPCUA")
-  field(INP, "@$(SESS) i=2264")
+  field(INP, "@$(SUBS) i=2264")
 }

--- a/exampleTop/TemplateDbSup/AnyServerDb/opcuaServerStats.template
+++ b/exampleTop/TemplateDbSup/AnyServerDb/opcuaServerStats.template
@@ -8,9 +8,10 @@
 # SUBS  subscription name
 
 # dynamic information (read on subscription)
-record(stringin, "$(P)$(R)CurrentTime") {
+record(stringin, "$(P)$(R)ServerCurrentTime") {
   field(DTYP, "OPCUA")
   field(INP, "@$(SUBS) i=2258")
+  field(SCAN, "I/O Intr")
 }
 record(mbbi, "$(P)$(R)ServerState") {
   field(DTYP, "OPCUA")
@@ -23,26 +24,31 @@ record(mbbi, "$(P)$(R)ServerState") {
   field(FVST, "Test")
   field(SXST, "CommunicationFault")
   field(SVST, "Unknown")
+  field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)CurrentSessionCount") {
   field(DTYP, "OPCUA")
   field(INP, "@$(SUBS) i=2277")
+  field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)CurrentSubscriptionCount") {
   field(DTYP, "OPCUA")
   field(INP, "@$(SUBS) i=2285")
+  field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)CumulatedSessionCount") {
   field(DTYP, "OPCUA")
   field(INP, "@$(SUBS) i=2278")
+  field(SCAN, "I/O Intr")
 }
 record(longin, "$(P)$(R)CumulatedSubscriptionCount") {
   field(DTYP, "OPCUA")
   field(INP, "@$(SUBS) i=2286")
+  field(SCAN, "I/O Intr")
 }
 
 # static information (always read when connecting)
-record(stringin, "$(P)$(R)StartTime") {
+record(stringin, "$(P)$(R)ServerStartTime") {
   field(DTYP, "OPCUA")
-  field(INP, "@$(SESS) i=2257")
+  field(INP, "@$(SUBS) i=2257")
 }


### PR DESCRIPTION
@ralphlange , Could you review these changes? 

And what about this record? 
```
record(mbbi, "$(P)$(R)ServerState") {
  field(DTYP, "OPCUA")
  field(INP, "@$(SUBS) i=2259")
  field(ZRST, "Running")
  field(ONST, "Failed")
  field(TWST, "NoConfiguration")
  field(THST, "Suspended")
  field(FRST, "Shutdown")
  field(FVST, "Test")
  field(SXST, "CommunicationFault")
  field(SVST, "Unknown")
  field(SCAN, "I/O Intr")
}
```

Even if I add `SCAN` into that record, it is a pretty useless one. When a server is gone, they still tells me "the server is running". Do we have any method to check this? 
