### PR TITLE
tested 3 different cases for GTEST

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -48,6 +48,11 @@ UASDK_DIR = $(UASDK)/lib
 UASDK_USE_CRYPTO = YES
 UASDK_USE_XMLPARSER = YES
 
+
+# Pointer to the Google Test location
+#   <not set> = do not use gtest
+#   SYSTEM    = libraries and headers are in a system location
+#   <path>    = libraries and headers are under <path>
 # Expect Google Test as system package
 GTEST_HOME = SYSTEM
 

--- a/googletest/googletest/Makefile
+++ b/googletest/googletest/Makefile
@@ -8,6 +8,8 @@ include $(TOP)/configure/CONFIG
 #================================================
 # Build GoogleTest libraries gtest and gtest_main
 
+ifdef GTEST_HOME
+
 GTEST = $(TOP)/googletest/googletest
 
 LIBRARY_HOST += gtest
@@ -21,6 +23,7 @@ gtest_main_SRCS += gtest_main.cc
 
 SHARED_LIBRARIES = NO
 
+endif
 #===========================
 
 include $(TOP)/configure/RULES

--- a/gtestSup/CONFIG_GTEST
+++ b/gtestSup/CONFIG_GTEST
@@ -1,8 +1,0 @@
-# Pointer to the Google Test location
-#   <not set> = do not use gtest
-#   SYSTEM    = libraries and headers are in a system location
-#   <path>    = libraries and headers are under <path>
-
-GTEST_HOME = SYSTEM
-
-# Remember that Google Test needs C++11 to be activated

--- a/gtestSup/Makefile
+++ b/gtestSup/Makefile
@@ -20,7 +20,6 @@ gtest_DIR = $(GTEST_HOME)/googletest
 endif
 
 CFG += RULES_GTEST
-CFG += CONFIG_GTEST
 
 endif
 

--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -5,6 +5,9 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+
+ifdef GTEST_HOME
+
 USR_INCLUDES += -I$(TOP)/devOpcuaSup
 
 #==================================================
@@ -22,6 +25,7 @@ TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 
 USR_LIBS += Com
 
+endif
 #===========================
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
@ralphlange 

* Remove duplicated `GTEST_HOME` in different files
* Move `GTEST_HOME` configuration in `configure/CONFIG_SITE`
* Skip googletest, if we define `GTEST_HOME` as empty

#### Case 1
   `GTEST_HOME=SYSTEM` with debian packages

#### Case 2
   `GTEST_HOME=$(CURIDR)/googletest`

#### Case 3
   `GTEST_HOME=`

Let me know what you think. 