### PR TITLE
Query server namespace array when connecting

### DIFF
--- a/devOpcuaSup/Session.h
+++ b/devOpcuaSup/Session.h
@@ -117,6 +117,14 @@ public:
     virtual void setOption(const std::string &name, const std::string &value) = 0;
 
     /**
+     * @brief Add namespace index mapping (local index -> URI).
+     *
+     * @param nsIndex  local namespace index
+     * @param uri  namespace URI
+     */
+    virtual void addNamespaceMapping(const unsigned short nsIndex, const std::string &uri) = 0;
+
+    /**
      * @brief Factory method to create a session (implementation specific).
      *
      * @param name         name of the new session

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -38,8 +38,6 @@ ItemUaSdk::ItemUaSdk (const linkInfo &info)
     , revisedQueueSize(0)
     , lastStatus(OpcUa_BadServerNotConnected)    
 {
-    rebuildNodeId();
-
     if (linkinfo.subscription != "" && linkinfo.monitor) {
         subscription = &SubscriptionUaSdk::findSubscription(linkinfo.subscription);
         subscription->addItemUaSdk(this);
@@ -59,10 +57,11 @@ ItemUaSdk::~ItemUaSdk ()
 void
 ItemUaSdk::rebuildNodeId ()
 {
+    OpcUa_UInt16 ns = session->mapNamespaceIndex(linkinfo.namespaceIndex);
     if (linkinfo.identifierIsNumeric) {
-        nodeid = std::unique_ptr<UaNodeId>(new UaNodeId(linkinfo.identifierNumber, linkinfo.namespaceIndex));
+        nodeid = std::unique_ptr<UaNodeId>(new UaNodeId(linkinfo.identifierNumber, ns));
     } else {
-        nodeid = std::unique_ptr<UaNodeId>(new UaNodeId(linkinfo.identifierString.c_str(), linkinfo.namespaceIndex));
+        nodeid = std::unique_ptr<UaNodeId>(new UaNodeId(linkinfo.identifierString.c_str(), ns));
     }
     registered = false;
 }
@@ -71,7 +70,11 @@ void
 ItemUaSdk::show (int level) const
 {
     std::cout << "item"
-              << " ns="     << linkinfo.namespaceIndex;
+              << " ns=";
+    if (nodeid && (nodeid->namespaceIndex() != linkinfo.namespaceIndex))
+        std::cout << nodeid->namespaceIndex() << "(" << linkinfo.namespaceIndex << ")";
+    else
+        std::cout << linkinfo.namespaceIndex;
     if (linkinfo.identifierIsNumeric)
         std::cout << ";i=" << linkinfo.identifierNumber;
     else

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -472,6 +472,23 @@ SessionUaSdk::rebuildNodeIds ()
         it->rebuildNodeId();
 }
 
+/* Add a mapping to the session's map, replacing any existing mappings with the same
+ * index or URI */
+void
+SessionUaSdk::addNamespaceMapping (const OpcUa_UInt16 nsIndex, const std::string &uri)
+{
+    for (auto &it : namespaceMap) {
+        if (it.second == nsIndex) {
+            namespaceMap.erase(it.first);
+            break;
+        }
+    }
+    auto it = namespaceMap.find(uri);
+    if (it != namespaceMap.end())
+        namespaceMap.erase(uri);
+    namespaceMap.insert({uri, nsIndex});
+}
+
 /* If a local namespaceMap exists, create a local->remote numerical index mapping
  * for every URI that is found both there and in the server's array */
 void

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -530,6 +530,17 @@ SessionUaSdk::show (const int level) const
               << " subscriptions=" << subscriptions.size()
               << std::endl;
 
+    if (level >= 3) {
+        if (namespaceMap.size()) {
+            std::cout << "Configured Namespace Mapping "
+                      << "(local -> Namespace URI -> server)" << std::endl;
+            for (auto p : namespaceMap) {
+                std::cout << " " << p.second << " -> " << p.first << " -> "
+                          << mapNamespaceIndex(p.second) << std::endl;
+            }
+        }
+    }
+
     if (level >= 1) {
         for (auto &it : subscriptions) {
             it.second->show(level-1);

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -506,6 +506,13 @@ SessionUaSdk::updateNamespaceMap(const UaStringArray &nsArray)
             if (it != namespaceMap.end())
                 nsIndexMap.insert({it->second, i});
         }
+        // Report all local mappings that were not found on server
+        for (auto it : namespaceMap) {
+            if (nsIndexMap.find(it.second) == nsIndexMap.end()) {
+                errlogPrintf("OPC UA session %s: locally mapped namespace '%s' not found on server\n",
+                             name.c_str(), it.first.c_str());
+            }
+        }
     }
 }
 

--- a/devOpcuaSup/UaSdk/SessionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.h
@@ -181,6 +181,11 @@ public:
      */
     virtual void setOption(const std::string &name, const std::string &value) override;
 
+    /**
+     * @brief Add namespace index mapping (local). See DevOpcua::Session::addNamespaceMapping
+     */
+    virtual void addNamespaceMapping(const OpcUa_UInt16 nsIndex, const std::string &uri) override;
+
     unsigned int noOfSubscriptions() const { return static_cast<unsigned int>(subscriptions.size()); }
     unsigned int noOfItems() const { return static_cast<unsigned int>(items.size()); }
 

--- a/devOpcuaSup/UaSdk/SessionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.h
@@ -199,6 +199,15 @@ public:
     void removeItemUaSdk(ItemUaSdk *item);
 
     /**
+     * @brief Map namespace index (local -> server)
+     *
+     * @param nsIndex  local namespace index
+     *
+     * @return server-side namespace index
+     */
+    OpcUa_UInt16 mapNamespaceIndex(const OpcUa_UInt16 nsIndex) const;
+
+    /**
      * @brief EPICS IOC Database initHook function.
      *
      * Hook function called when the EPICS IOC is being initialized.
@@ -251,6 +260,11 @@ private:
      */
     void rebuildNodeIds();
 
+    /**
+     * @brief Rebuild the namespace index map from the server's array.
+     */
+    void updateNamespaceMap(const UaStringArray &nsArray);
+
     static std::map<std::string, SessionUaSdk *> sessions;    /**< session management */
 
     const std::string name;                                   /**< unique session name */
@@ -259,6 +273,8 @@ private:
     std::map<std::string, SubscriptionUaSdk*> subscriptions;  /**< subscriptions on this session */
     std::vector<ItemUaSdk *> items;                           /**< items on this session */
     OpcUa_UInt32 registeredItemsNo;                           /**< number of registered items */
+    std::map<std::string, OpcUa_UInt16> namespaceMap;         /**< local namespace map (URI->index) */
+    std::map<OpcUa_UInt16, OpcUa_UInt16> nsIndexMap;          /**< namespace index map (local->server-side) */
     UaSession* puasession;                                    /**< pointer to low level session */
     SessionConnectInfo connectInfo;                           /**< connection metadata */
     SessionSecurityInfo securityInfo;                         /**< security metadata */

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -190,6 +190,53 @@ void opcuaSetOptionCallFunc (const iocshArgBuf *args)
     }
 }
 
+static const iocshArg opcuaMapNamespaceArg0 = {"session name", iocshArgString};
+static const iocshArg opcuaMapNamespaceArg1 = {"namespace index", iocshArgInt};
+static const iocshArg opcuaMapNamespaceArg2 = {"namespace URI", iocshArgString};
+
+static const iocshArg *const opcuaMapNamespaceArg[3] = {&opcuaMapNamespaceArg0, &opcuaMapNamespaceArg1,
+                                                        &opcuaMapNamespaceArg2};
+
+static const iocshFuncDef opcuaMapNamespaceFuncDef = {"opcuaMapNamespace", 3, opcuaMapNamespaceArg};
+
+static
+void opcuaMapNamespaceCallFunc (const iocshArgBuf *args)
+{
+    try {
+        bool ok = true;
+        unsigned short index = 0;
+
+        if (args[0].sval == nullptr) {
+            errlogPrintf("missing argument #1 (session name)\n");
+            ok = false;
+        } else if (!Session::sessionExists(args[0].sval)) {
+            errlogPrintf("'%s' - no such session\n",
+                         args[0].sval);
+            ok = false;
+        }
+
+        if (args[1].ival < 0 || args[1].ival > USHRT_MAX) {
+            errlogPrintf("invalid argument #2 (namespace index) '%d'\n",
+                         args[1].ival);
+        } else {
+            index = static_cast<unsigned short>(args[1].ival);
+        }
+
+        if (args[2].sval == nullptr) {
+            errlogPrintf("missing argument #3 (namespace URI)\n");
+            ok = false;
+        }
+
+        if (ok) {
+            Session &sess = Session::findSession(args[0].sval);
+            sess.addNamespaceMapping(index, args[2].sval);
+        }
+    }
+    catch(std::exception& e) {
+        std::cerr << "ERROR : " << e.what() << std::endl;
+    }
+}
+
 static const iocshArg opcuaShowSessionArg0 = {"session name", iocshArgString};
 static const iocshArg opcuaShowSessionArg1 = {"verbosity", iocshArgInt};
 
@@ -412,6 +459,7 @@ void opcuaIocshRegister ()
 {
     iocshRegister(&opcuaCreateSessionFuncDef, opcuaCreateSessionCallFunc);
     iocshRegister(&opcuaSetOptionFuncDef, opcuaSetOptionCallFunc);
+    iocshRegister(&opcuaMapNamespaceFuncDef, opcuaMapNamespaceCallFunc);
 
     iocshRegister(&opcuaConnectFuncDef, opcuaConnectCallFunc);
     iocshRegister(&opcuaDisconnectFuncDef, opcuaDisconnectCallFunc);

--- a/unitTestApp/src/UaSdk/Makefile
+++ b/unitTestApp/src/UaSdk/Makefile
@@ -17,3 +17,8 @@ USR_INCLUDES += -I$(TOP)/devOpcuaSup/UaSdk
 GTESTPROD_HOST += RangeCheckTest
 RangeCheckTest_SRCS += RangeCheckTest.cpp
 GTESTS += RangeCheckTest
+
+GTESTPROD_HOST += NamespaceMapTest
+NamespaceMapTest_SRCS += NamespaceMapTest.cpp
+NamespaceMapTest_LIBS += opcua
+GTESTS += NamespaceMapTest

--- a/unitTestApp/src/UaSdk/NamespaceMapTest.cpp
+++ b/unitTestApp/src/UaSdk/NamespaceMapTest.cpp
@@ -1,0 +1,46 @@
+/*************************************************************************\
+* Copyright (c) 2020 ITER Organization.
+* This module is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/*
+ *  Author: Ralph Lange <ralph.lange@gmx.de>
+ */
+
+#include <gtest/gtest.h>
+
+#include <epicsTypes.h>
+
+#include "SessionUaSdk.h"
+
+namespace {
+
+using namespace DevOpcua;
+
+TEST(NamespaceMapTest, NoMapping) {
+    SessionUaSdk *sess = new SessionUaSdk("test", "url");
+
+    for (unsigned int i = 0; i <= USHRT_MAX; i++) {
+        OpcUa_UInt16 ns = static_cast<OpcUa_UInt16>(i);
+        EXPECT_EQ(ns, sess->mapNamespaceIndex(ns)) << "numerical index mapped without mapping table";
+    }
+}
+
+TEST(NamespaceMapTest, UnusedMapping) {
+    SessionUaSdk *sess = new SessionUaSdk("test", "url");
+
+    sess->addNamespaceMapping(1u, "one");
+    sess->addNamespaceMapping(2u, "two");
+
+    for (unsigned int i = 0; i <= USHRT_MAX; i++) {
+        OpcUa_UInt16 ns = static_cast<OpcUa_UInt16>(i);
+        EXPECT_EQ(ns, sess->mapNamespaceIndex(ns)) << "numerical index changed without valid mapping";
+    }
+}
+
+// More tests will need a semi-fuctional mock
+// - to feed the namespace array into the table
+// - to simulate server reboots with namespace array change
+
+} // namespace


### PR DESCRIPTION
This PR adds reading of the server's namespace array when a connection comes up.

The new iocShell command `opcuaMapNamespace <session> <index> <URI>` adds an entry to the local mapping of index numbers to URIs.

The session reads the server's namespace table on connection.
When the server's array contains a URL that matches one in the local table, a number-to-number mapping for the running session is created.

Closes #68.