### PR TITLE
Add link option 'bini' to set record behavior on reconnection

### DIFF
--- a/devOpcuaSup/RecordConnector.h
+++ b/devOpcuaSup/RecordConnector.h
@@ -29,6 +29,7 @@
 #include "devOpcua.h"
 #include "DataElement.h"
 #include "Item.h"
+#include "opcuaItemRecord.h"
 
 namespace DevOpcua {
 
@@ -95,6 +96,12 @@ public:
     const char *getRecordName() const { return prec->name; }
     const char *getRecordType() const { return prec->rdes->name; }
     menuPriority getRecordPriority() const { return static_cast<menuPriority>(prec->prio); }
+    LinkOptionBini bini() const {
+        if (plinkinfo->isItemRecord)
+            return reinterpret_cast<opcuaItemRecord*>(prec)->bini;
+        else
+            return plinkinfo->bini;
+    }
 
     int debug() const { return prec->tpro; }
 
@@ -113,6 +120,7 @@ public:
     bool isIoIntrScanned;
     IOSCANPVT ioscanpvt;
     ProcessReason reason;
+
 private:
     dbCommon *prec;
     CALLBACK incomingDataCallback;

--- a/devOpcuaSup/RecordConnector.h
+++ b/devOpcuaSup/RecordConnector.h
@@ -98,7 +98,7 @@ public:
     menuPriority getRecordPriority() const { return static_cast<menuPriority>(prec->prio); }
     LinkOptionBini bini() const {
         if (plinkinfo->isItemRecord)
-            return reinterpret_cast<opcuaItemRecord*>(prec)->bini;
+            return static_cast<LinkOptionBini>(reinterpret_cast<opcuaItemRecord*>(prec)->bini);
         else
             return plinkinfo->bini;
     }

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -66,7 +66,7 @@ DataElementUaSdk::show (const int level, const unsigned int indent) const
                   << pconnector->getRecordName()
                   << " type=" << variantTypeString(incomingData.type())
                   << " timestamp=" << (pconnector->plinkinfo->useServerTimestamp ? "server" : "source")
-                  << " pini=" << linkOptionPiniString(pconnector->plinkinfo->pini)
+                  << " bini=" << linkOptionBiniString(pconnector->plinkinfo->bini)
                   << " monitor=" << (pconnector->plinkinfo->monitor ? "y" : "n") << "\n";
     } else {
         std::cout << "node=" << name << " children=" << elements.size()
@@ -202,7 +202,7 @@ DataElementUaSdk::setIncomingData (const UaVariant &value, ProcessReason reason)
         if (reason == ProcessReason::readComplete || pconnector->plinkinfo->monitor) {
             Guard(pconnector->lock);
             if (pitem->state() != ConnectionStatus::initialRead ||
-                    pconnector->plinkinfo->pini == LinkOptionPini::read) {
+                    pconnector->plinkinfo->bini == LinkOptionBini::read) {
                 bool wasFirst = false;
                 // Make a copy of the value for this element and put it on the queue
                 UpdateUaSdk *u(new UpdateUaSdk(getIncomingTimeStamp(), reason, value, getIncomingReadStatus()));

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -66,6 +66,7 @@ DataElementUaSdk::show (const int level, const unsigned int indent) const
                   << pconnector->getRecordName()
                   << " type=" << variantTypeString(incomingData.type())
                   << " timestamp=" << (pconnector->plinkinfo->useServerTimestamp ? "server" : "source")
+                  << " pini=" << linkOptionPiniString(pconnector->plinkinfo->pini)
                   << " monitor=" << (pconnector->plinkinfo->monitor ? "y" : "n") << "\n";
     } else {
         std::cout << "node=" << name << " children=" << elements.size()

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -90,7 +90,7 @@ ItemUaSdk::show (int level) const
               << " cqsize=" << linkinfo.clientQueueSize
               << " discard=" << (linkinfo.discardOldest ? "old" : "new")
               << " timestamp=" << (linkinfo.useServerTimestamp ? "server" : "source")
-              << " pini=" << linkOptionPiniString(linkinfo.pini)
+              << " bini=" << linkOptionBiniString(linkinfo.bini)
               << " output=" << (linkinfo.isOutput ? "y" : "n")
               << " monitor=" << (linkinfo.monitor ? "y" : "n")
               << " registered=" << (registered ? nodeid->toString().toUtf8() : "-" )

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -164,8 +164,18 @@ ItemUaSdk::setIncomingData(const OpcUa_DataValue &value, ProcessReason reason)
     if (auto pd = rootElement.lock())
         pd->setIncomingData(value.Value, reason);
 
-    if (linkinfo.isItemRecord)
-        recConnector->requestRecordProcessing(reason);
+    if (linkinfo.isItemRecord) {
+        if (state() == ConnectionStatus::initialRead) {
+            if (recConnector->bini() == LinkOptionBini::write) {
+                setState(ConnectionStatus::initialWrite);
+                recConnector->requestRecordProcessing(ProcessReason::writeRequest);
+            } else {
+                setState(ConnectionStatus::up);
+            }
+        } else {
+            recConnector->requestRecordProcessing(reason);
+        }
+    }
 }
 
 void

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -87,6 +87,7 @@ ItemUaSdk::show (int level) const
               << " cqsize=" << linkinfo.clientQueueSize
               << " discard=" << (linkinfo.discardOldest ? "old" : "new")
               << " timestamp=" << (linkinfo.useServerTimestamp ? "server" : "source")
+              << " pini=" << linkOptionPiniString(linkinfo.pini)
               << " output=" << (linkinfo.isOutput ? "y" : "n")
               << " monitor=" << (linkinfo.monitor ? "y" : "n")
               << " registered=" << (registered ? nodeid->toString().toUtf8() : "-" )

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************\
-* Copyright (c) 2018-2019 ITER Organization.
+* Copyright (c) 2018-2020 ITER Organization.
 * This module is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
@@ -36,7 +36,9 @@ ItemUaSdk::ItemUaSdk (const linkInfo &info)
     , registered(false)
     , revisedSamplingInterval(0.0)
     , revisedQueueSize(0)
-    , lastStatus(OpcUa_BadServerNotConnected)    
+    , lastStatus(OpcUa_BadServerNotConnected)
+    , lastReason(ProcessReason::connectionLoss)
+    , connState(ConnectionStatus::down)
 {
     rebuildNodeId();
 
@@ -77,6 +79,7 @@ ItemUaSdk::show (int level) const
     else
         std::cout << ";s=" << linkinfo.identifierString;
     std::cout << " record=" << recConnector->getRecordName()
+              << " state=" << connectionStatusString(connState)
               << " status=" << UaStatus(lastStatus).toString().toUtf8()
               << " context=" << linkinfo.subscription
               << "@" << session->getName()

--- a/devOpcuaSup/UaSdk/ItemUaSdk.h
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.h
@@ -117,6 +117,18 @@ public:
     UaStatusCode getLastStatus() { return lastStatus; }
 
     /**
+     * @brief Setter for the EPICS-related state of the item.
+     * @param newState  state to be set
+     */
+    void setState(const ConnectionStatus state) { connState = state; }
+
+    /**
+     * @brief Getter for EPICS-related state of the item.
+     * @return EPICS-related connection state
+     */
+    ConnectionStatus state() { return connState; }
+
+    /**
      * @brief Setter for the reason of an operation.
      * @param reason  new reason to be cached
      */
@@ -215,6 +227,7 @@ private:
     std::weak_ptr<DataElementUaSdk> rootElement;  /**< top level data element */
     UaStatusCode lastStatus;               /**< status code of most recent service */
     ProcessReason lastReason;              /**< most recent processing reason */
+    ConnectionStatus connState;            /**< Connection state of the item */
     epicsTime tsClient;                    /**< client (local) time stamp */
     epicsTime tsServer;                    /**< server time stamp */
     epicsTime tsSource;                    /**< device time stamp */

--- a/devOpcuaSup/devOpcua.cpp
+++ b/devOpcuaSup/devOpcua.cpp
@@ -94,6 +94,7 @@ opcua_add_record (dbCommon *prec)
         std::unique_ptr<RecordConnector> pvt (new RecordConnector(prec));
         ItemUaSdk *pitem;
         pvt->plinkinfo = parseLink(prec, ent);
+        if (prec->pini) reportPiniAndClear(prec);
         //TODO: Switch to implementation selection / factory
         if (pvt->plinkinfo->linkedToItem) {
             pitem = new ItemUaSdk(*pvt->plinkinfo);

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -13,6 +13,7 @@
 #ifndef DEVOPCUA_H
 #define DEVOPCUA_H
 
+#include <iostream>
 #include <sstream>
 #include <cstring>
 #include <memory>
@@ -28,7 +29,7 @@ namespace DevOpcua {
 class Item;
 
 /**
- * @brief Enum for the choices of the pini link option
+ * @brief Enum for the choices of the pini link option.
  */
 enum LinkOptionPini { read, ignore, write };
 
@@ -41,6 +42,19 @@ linkOptionPiniString (const LinkOptionPini choice)
     case write:  return "write";
     }
     return "Illegal Value";
+}
+
+/**
+ * @brief Report that PINI is set for a record and clear it.
+ *
+ * @param prec  pointer to record
+ */
+inline void
+reportPiniAndClear (dbCommon *prec) {
+    std::cerr << prec->name << " uses PINI, which does not work with the OPC UA Device support"
+              << " - disabling it (check the 'pini' link option instead)"
+              << std::endl;
+    prec->pini = 0;
 }
 
 /** @brief Configuration data for a single record instance.

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -29,12 +29,12 @@ namespace DevOpcua {
 class Item;
 
 /**
- * @brief Enum for the choices of the pini link option.
+ * @brief Enum for the choices of the bini link option.
  */
-enum LinkOptionPini { read, ignore, write };
+enum LinkOptionBini { read, ignore, write };
 
 inline const char *
-linkOptionPiniString (const LinkOptionPini choice)
+linkOptionBiniString (const LinkOptionBini choice)
 {
     switch(choice) {
     case read:   return "read";
@@ -52,7 +52,7 @@ linkOptionPiniString (const LinkOptionPini choice)
 inline void
 reportPiniAndClear (dbCommon *prec) {
     std::cerr << prec->name << " uses PINI, which does not work with the OPC UA Device support"
-              << " - disabling it (check the 'pini' link option instead)"
+              << " - disabling it (check the 'bini' link option instead)"
               << std::endl;
     prec->pini = 0;
 }
@@ -87,7 +87,7 @@ typedef struct linkInfo {
 
     std::string element;
     bool useServerTimestamp = true;
-    LinkOptionPini pini = LinkOptionPini::read;
+    LinkOptionBini bini = LinkOptionBini::read;
 
     bool isOutput;
     bool monitor = true;

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -118,6 +118,22 @@ processReasonString (const ProcessReason type)
     return "Illegal Value";
 }
 
+/**
+ * @brief Enum for the EPICS related state of an OPC UA variable
+ */
+enum ConnectionStatus { down, initialRead, initialWrite, up };
+
+inline const char *
+connectionStatusString (const ConnectionStatus status) {
+    switch(status) {
+    case down:         return "down";
+    case initialRead:  return "initialRead";
+    case initialWrite: return "initialWrite";
+    case up:           return "up";
+    }
+    return "Illegal Value";
+}
+
 template<typename R>
 struct dset6 {
     long N;

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -27,6 +27,22 @@ namespace DevOpcua {
 
 class Item;
 
+/**
+ * @brief Enum for the choices of the pini link option
+ */
+enum LinkOptionPini { read, ignore, write };
+
+inline const char *
+linkOptionPiniString (const LinkOptionPini choice)
+{
+    switch(choice) {
+    case read:   return "read";
+    case ignore: return "ignore";
+    case write:  return "write";
+    }
+    return "Illegal Value";
+}
+
 /** @brief Configuration data for a single record instance.
  *
  * This structure holds all configuration data for a single instance of
@@ -57,6 +73,7 @@ typedef struct linkInfo {
 
     std::string element;
     bool useServerTimestamp = true;
+    LinkOptionPini pini = LinkOptionPini::read;
 
     bool isOutput;
     bool monitor = true;

--- a/devOpcuaSup/linkParser.cpp
+++ b/devOpcuaSup/linkParser.cpp
@@ -232,13 +232,13 @@ parseLink (dbCommon *prec, const DBEntry &ent)
             }
         } else if (optname == "element") {
             pinfo->element = optval;
-        } else if (optname == "pini") {
+        } else if (optname == "bini") {
             if (optval == "read")
-                pinfo->pini = LinkOptionPini::read;
+                pinfo->bini = LinkOptionBini::read;
             else if (optval == "ignore")
-                pinfo->pini = LinkOptionPini::ignore;
+                pinfo->bini = LinkOptionBini::ignore;
             else if ((pinfo->isItemRecord || pinfo->isOutput) && optval == "write")
-                pinfo->pini = LinkOptionPini::write;
+                pinfo->bini = LinkOptionBini::write;
             else
                 throw std::runtime_error(SB() << "illegal value '" << optval << "' for option '" << optname << "'");
         } else {
@@ -277,7 +277,7 @@ parseLink (dbCommon *prec, const DBEntry &ent)
         std::cout << " timestamp=" << (pinfo->useServerTimestamp ? "server" : "source")
                   << " output=" << (pinfo->isOutput ? "y" : "n")
                   << " monitor=" << (pinfo->monitor ? "y" : "n")
-                  << " pini=" << linkOptionPiniString(pinfo->pini)
+                  << " bini=" << linkOptionBiniString(pinfo->bini)
                   << std::endl;
     }
 

--- a/devOpcuaSup/linkParser.cpp
+++ b/devOpcuaSup/linkParser.cpp
@@ -232,6 +232,15 @@ parseLink (dbCommon *prec, const DBEntry &ent)
             }
         } else if (optname == "element") {
             pinfo->element = optval;
+        } else if (optname == "pini") {
+            if (optval == "read")
+                pinfo->pini = LinkOptionPini::read;
+            else if (optval == "ignore")
+                pinfo->pini = LinkOptionPini::ignore;
+            else if ((pinfo->isItemRecord || pinfo->isOutput) && optval == "write")
+                pinfo->pini = LinkOptionPini::write;
+            else
+                throw std::runtime_error(SB() << "illegal value '" << optval << "' for option '" << optname << "'");
         } else {
             throw std::runtime_error(SB() << "invalid option '" << optname << "'");
         }
@@ -268,6 +277,7 @@ parseLink (dbCommon *prec, const DBEntry &ent)
         std::cout << " timestamp=" << (pinfo->useServerTimestamp ? "server" : "source")
                   << " output=" << (pinfo->isOutput ? "y" : "n")
                   << " monitor=" << (pinfo->monitor ? "y" : "n")
+                  << " pini=" << linkOptionPiniString(pinfo->pini)
                   << std::endl;
     }
 

--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -64,6 +64,7 @@ init_record (dbCommon *pdbc, int pass)
             DBEntry ent(pdbc);
             std::unique_ptr<RecordConnector> pvt (new RecordConnector(pdbc));
             pvt->plinkinfo = parseLink(pdbc, ent);
+            if (pdbc->pini) reportPiniAndClear(pdbc);
             ItemUaSdk *pitem = new ItemUaSdk(*pvt->plinkinfo); //FIXME: replace item creation with factory call
             pitem->recConnector = pvt.get();
             pvt->pitem = pitem;

--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -73,6 +73,8 @@ init_record (dbCommon *pdbc, int pass)
             prec->sess[MAX_STRING_SIZE] = '\0';
             strncpy(prec->subs, pitem->linkinfo.subscription.c_str(), MAX_STRING_SIZE);
             prec->subs[MAX_STRING_SIZE] = '\0';
+            if (!prec->bini)
+                prec->bini = pitem->linkinfo.bini;
         } catch(std::exception& e) {
             std::cerr << prec->name << " Error in init_record : " << e.what() << std::endl;
             return S_dbLib_badLink;

--- a/devOpcuaSup/opcuaItemRecord.dbd
+++ b/devOpcuaSup/opcuaItemRecord.dbd
@@ -4,6 +4,13 @@
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
 
+# Menu for 'bini' parameter/field
+menu(menuBini) {
+        choice(menuBiniREAD, "read")
+        choice(menuBiniIGNORE, "ignore")
+        choice(menuBiniWRITE, "write")
+}
+
 recordtype(opcuaItem) {
     include "dbCommon.dbd"
     field(VAL,DBF_NOACCESS) {
@@ -35,6 +42,12 @@ recordtype(opcuaItem) {
         promptgroup("30 - Action")
         interest(1)
         menu(menuDefAction)
+    }
+    field(BINI,DBF_MENU) {
+        prompt("Behavior at Initialization")
+        promptgroup("20 - Scan")
+        interest(1)
+        menu(menuBini)
     }
     field(READ,DBF_UCHAR) {
         prompt("Force Read Processing")


### PR DESCRIPTION
This PR adds the 'pini' link option as proposed in #62.
It also fixes a segfault connected to records with `PINI=YES` setting (#71).

(resolves #62; fixes #71)