### PR TITLE
Windows build - changes for building the module on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 to the OPC UA protocol. The architecture allows supporting different
 implementations of the low level client library.
 
+Linux and Windows builds are supported.
+
 ## Status
 
 :warning:
@@ -20,7 +22,9 @@ commercially available Unified Automation C++ Based OPC UA Client SDK.
 
 ## Prerequisites
 
-*   A C++ compiler that supports the C++11 standard.
+*   A C++ compiler that supports the C++11 standard. \
+    Microsoft Visual C++ needs to be from Visual Studio 2015 or newer.
+    g++ needs to be 4.6 or above.
 
 *   [EPICS Base](https://epics-controls.org/resources-and-support/base/)
     3.15.5 (and up; EPICS 7 is supported).
@@ -31,11 +35,11 @@ commercially available Unified Automation C++ Based OPC UA Client SDK.
 ### Using the Unified Automation Client SDK
 
 *   Unified Automation C++ Based [OPC UA Client SDK][unified.sdk]
-    (1.5/1.6/1.7 are supported, as well as their evaluation bundle).
+    (1.5/1.6/1.7 are supported, as well as their evaluation bundles).
 
 *   For OPC UA security support (authentication/encryption), you need
-    libcrypto on your system - both when compiling the SDK and when generating
-    any binaries (IOCs).
+    openssl/libcrypto on your system - both when compiling the SDK and when
+    generating any binaries (IOCs).
 
 *   For more details, refer to the `README.md` in the
     [`devOpcuaSup/UaSdk`][uasdk.dir] directory.
@@ -91,8 +95,9 @@ Please use the GitHub project's
 
 This module is based on extensive
 [prototype work](https://github.com/bkuner/opcUaUnifiedAutomation)
-by Bernhard Kuner (HZB/BESSY II) and uses ideas and code snippets from
+by Bernhard Kuner (HZB/BESSY) and uses ideas and code snippets from
 Michael Davidsaver (Osprey DCS).
+Additional help from Carsten Winkler (HZB/BESSY).
 
 ## License
 

--- a/configure/CONFIG_SITE.Common.win32-x86
+++ b/configure/CONFIG_SITE.Common.win32-x86
@@ -1,9 +1,18 @@
 # Second-level dependencies of the UA SDK
 
-# the "vs2015" part depends on the UASDK version
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/libxml2/out32dll
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/openssl/out32dll
+# Different UASDK bundles have third-party modules in different locations
+# and different versions of the openssl library with different library names
 
-USR_INCLUDES_WIN32 += -I$(UASDK)/third-party/win64/vs2015/openssl/inc32
+UASDK_3RDPARTY = $(firstword $(wildcard $(UASDK)/third-party/win64/vs2015 \
+$(UASDK)/third-party/win32/vs2015))
 
-USR_SYS_LIBS_WIN32 += ssleay32 libeay32 crypt32 libxml2 oleaut32 ole32 ws2_32
+UASDK_CRYPTO_LIBS = $(patsubst %.dll,%$(D),$(notdir $(wildcard \
+$(UASDK_3RDPARTY)/openssl/out32dll/libssl.dll \
+$(UASDK_3RDPARTY)/openssl/out32dll/libcrypto.dll \
+$(UASDK_3RDPARTY)/openssl/out32dll/ssleay32.dll \
+$(UASDK_3RDPARTY)/openssl/out32dll/libeay32.dll)))
+
+USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK_3RDPARTY)/openssl/out32dll$(D_DIR)
+USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK_3RDPARTY)/libxml2/out32dll$(D_DIR)
+USR_INCLUDES_WIN32 += -I$(UASDK_3RDPARTY)/openssl/inc32 -I$(UASDK_3RDPARTY)/libxml2/include
+USR_SYS_LIBS_WIN32 += $(UASDK_CRYPTO_LIBS) libxml2$(D) oleaut32 ole32 ws2_32

--- a/configure/CONFIG_SITE.Common.win32-x86
+++ b/configure/CONFIG_SITE.Common.win32-x86
@@ -1,7 +1,9 @@
 # Second-level dependencies of the UA SDK
 
 # the "vs2015" part depends on the UASDK version
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win32/vs2015/libxml2/out32dll
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win32/vs2015/openssl/out32dll
+USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/libxml2/out32dll
+USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/openssl/out32dll
+
+USR_INCLUDES_WIN32 += -I$(UASDK)/third-party/win64/vs2015/openssl/inc32
 
 USR_SYS_LIBS_WIN32 += ssleay32 libeay32 crypt32 libxml2 oleaut32 ole32 ws2_32

--- a/configure/CONFIG_SITE.Common.win32-x86-debug
+++ b/configure/CONFIG_SITE.Common.win32-x86-debug
@@ -1,1 +1,3 @@
+D = d
+D_DIR = .dbg
 include $(TOP)/configure/CONFIG_SITE.Common.win32-x86

--- a/configure/CONFIG_SITE.Common.windows-x64
+++ b/configure/CONFIG_SITE.Common.windows-x64
@@ -1,7 +1,1 @@
-# Second-level dependencies of the UA SDK
-
-# the "vs2015" part depends on the UASDK version
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/libxml2/out32dll
-USR_LDFLAGS_WIN32 += /LIBPATH:$(UASDK)/third-party/win64/vs2015/openssl/out32dll
-
-USR_SYS_LIBS_WIN32 += ssleay32 libeay32 crypt32 libxml2 oleaut32 ole32 ws2_32
+include $(TOP)/configure/CONFIG_SITE.Common.win32-x86

--- a/configure/CONFIG_SITE.Common.windows-x64-debug
+++ b/configure/CONFIG_SITE.Common.windows-x64-debug
@@ -1,1 +1,1 @@
-include $(TOP)/configure/CONFIG_SITE.Common.windows-x64
+include $(TOP)/configure/CONFIG_SITE.Common.win32-x86-debug

--- a/devOpcuaSup/Session.h
+++ b/devOpcuaSup/Session.h
@@ -15,6 +15,8 @@
 
 #include <string>
 
+#include <shareLib.h>
+
 namespace DevOpcua {
 
 /**
@@ -30,7 +32,7 @@ namespace DevOpcua {
  * and freeing all related resources on both server and client.
  */
 
-class Session
+class epicsShareClass Session
 {
 public:
     virtual ~Session() {}

--- a/devOpcuaSup/Subscription.h
+++ b/devOpcuaSup/Subscription.h
@@ -17,6 +17,7 @@
 #include <map>
 
 #include <epicsTypes.h>
+#include <shareLib.h>
 
 namespace DevOpcua {
 
@@ -28,7 +29,7 @@ class Session;
  * The interface provides all subscription related UA services.
  */
 
-class Subscription
+class epicsShareClass Subscription
 {
 public:
     virtual ~Subscription();

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -11,6 +11,11 @@
  *  and example code from the Unified Automation C++ Based OPC UA Client SDK
  */
 
+// Avoid problems on Windows (macros min, max clash with numeric_limits<>)
+#ifdef _WIN32
+#    define NOMINMAX
+#endif
+
 #include <iostream>
 #include <memory>
 #include <string>

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -11,6 +11,11 @@
  *  and example code from the Unified Automation C++ Based OPC UA Client SDK
  */
 
+// Avoid problems on Windows (macros min, max clash with numeric_limits<>)
+#ifdef _WIN32
+#    define NOMINMAX
+#endif
+
 #include <memory>
 #include <cstring>
 

--- a/devOpcuaSup/UaSdk/README.md
+++ b/devOpcuaSup/UaSdk/README.md
@@ -10,7 +10,17 @@ Please contact the author [Ralph Lange](mailto:ralph.lange@gmx.de) for details.
 ## Prerequisites
 
 *   Unified Automation C++ Based [OPC UA Client SDK][unified.sdk]
-    (1.5/1.6/1.7 are supported, as well as their evaluation bundle).
+    (1.5/1.6/1.7 are supported, as well as their evaluation bundles).
+    
+*   Windows and Linux builds are supported.
+
+*   Using the evaluation binary bundles by Unified Automation (free download)
+    is supported.
+    However, the EVAL bundle contains a shared library (DLL), namely the stack
+    component, see below, so only shared builds of this Device Support will
+    work.
+
+### Linux
 
 *   For OPC UA security support (authentication/encryption), you need
     libcrypto on your system - both when compiling the SDK and when generating
@@ -25,9 +35,9 @@ Please contact the author [Ralph Lange](mailto:ralph.lange@gmx.de) for details.
     ```Shell
     ./buildSdk.sh -s ON
     ```
-    In version 1.5.5 of the SDK, the `buildSdk.sh` build script does not apply
+    In many versions of the SDK, the `buildSdk.sh` build script does not apply
     the `-s ON` setting the the stack component. To fix this and create a complete
-    shared library set of the SDK, apply the following patch:
+    shared library set of the SDK, apply the following patch (shown for 1.5.5):
     ```Diff
     --- buildSdk.sh
     +++ buildSdk.sh
@@ -42,11 +52,11 @@ Please contact the author [Ralph Lange](mailto:ralph.lange@gmx.de) for details.
          # install
     ```
 
-*   Using the evaluation binary bundle of Unified Automation (free download)
-    is supported.
-    However, the EVAL bundle contains shared-only libraries (namely the stack
-    component, see above), so only shared builds of this Device Support will
-    work.
+### Windows
+
+*   Binary libraries (DLLs and static) of openssl and libxml2 are provided under the
+    `third-party` directory of the SDK bundle.
+
 
 ## Building the device support module
 
@@ -72,11 +82,6 @@ UASDK_USE_CRYPTO = YES
 UASDK_USE_XMLPARSER = YES
 ```
 
-Note: On Windows, paths must include "short names" where needed, e.g.
-```Makefile
-UASDK = C:/PROGRA~2/UnifiedAutomation/UaSdkCppBundleEval
-```
-
 The SDK related configuration only has to be done in this module,
 which creates a `CONFIG_OPCUA` file that is automatically included by all
 downstream modules, so that the configuration is always consistent.
@@ -84,6 +89,40 @@ downstream modules, so that the configuration is always consistent.
 When using the evaluation bundle of the SDK, only regular (shared) builds
 are supported.
 Do not set `STATIC_BUILD = YES` in your configuration.
+
+### Windows Specifics
+
+Windows builds should use `UASDK_DEPLOY_MODE = PROVIDED` and set `UASDK`
+to the location of the Unified Automation bundle.
+
+Paths must include Windows "short names" where needed, e.g.
+```Makefile
+UASDK = C:/PROGRA~2/UnifiedAutomation/UaSdkCppBundleEval
+```
+
+If you do not have Administrator rights or if you want to unpack multiple
+versions of the UA SDK bundle in parallel, [UniExtract2][uniextract2] is your
+friend.
+
+For any created binaries to successfully find the EPICS and SDK DLLs,
+both the binary locations of the EPICS Base installation and the UA SDK
+bundle installation have to be added to the PATH.
+This needs to be done before starting the build, as some created binaries
+(tests) are being run as part of the build.
+
+Please use your specific locations and "short names" when running a command
+like
+```Shell
+path %PATH%C:\Users\foobar\EPICS\base\7.0.4.1;C:\PROGRA~2\UnifiedAutomation\UaSdkCppBundleEval\bin;
+```
+
+Alternatively, you could copy all needed DLLs into the binary location of
+your IOC binary. Be aware that over time, this approach will lead to a large
+number of possibly different DLLs with the same name being used concurrently -
+a situation that is hard to maintain.
+If you want your IOC binaries to be deployable without depending on
+specific DLLs being present on the target system, you should consider linking
+your IOCs statically.
 
 ## Feedback / Reporting issues
 
@@ -98,12 +137,21 @@ getting updates anymore after the server has disconnected and reconnected.
 A reboot of the IOC restores good behaviour until the server disconnects
 again. Updating the C++ SDK to version 1.7.2 resolves the issue.
 
+Reported by Carsten Winkler (HZB/BESSY): \
+On Windows 10, you may experience a version mismatch between the openssl DLLs
+that are part of the Windows system and a different version of the same DLLs
+that are part of the UA SDK bundle.
+In that case, copying the DLLs from the UA SDK into the same directory as the
+unit tests (`...\unitTestApp\src\O.win...`) and your executable (IOC binary)
+seems to be the only reasonable workaround.
+
 ## Credits
 
 This module is based on extensive
 [prototype work](https://github.com/bkuner/opcUaUnifiedAutomation)
-by Bernhard Kuner (HZB/BESSY II) and uses ideas and code snippets from
+by Bernhard Kuner (HZB/BESSY) and uses ideas and code snippets from
 Michael Davidsaver (Osprey DCS).
+Support for Windows builds with help from Carsten Winkler (HZB/BESSY).
 
 ## License
 
@@ -112,3 +160,4 @@ in file LICENSE that is included with this distribution.
 
 <!-- Links -->
 [unified.sdk]: https://www.unified-automation.com/products/client-sdk/c-ua-client-sdk.html
+[uniextract2]: https://github.com/Bioruebe/UniExtract2

--- a/devOpcuaSup/UaSdk/RULES_OPCUA
+++ b/devOpcuaSup/UaSdk/RULES_OPCUA
@@ -41,7 +41,7 @@ ifdef OPCUA_NEEDS_INCLUDES
 USR_INCLUDES += -I$(UASDK)/include
 USR_INCLUDES += $(foreach lib, $(UASDK_LIBS),-I$(UASDK)/include/$(lib))
 # SDK libraries are not built with correct RUNPATH - rely on executable
-USR_LDFLAGS += -Wl,--disable-new-dtags
+USR_LDFLAGS_Linux += -Wl,--disable-new-dtags
 endif
 
 ifeq ($(UASDK_DEPLOY_MODE),SYSTEM)

--- a/devOpcuaSup/UaSdk/RULES_OPCUA
+++ b/devOpcuaSup/UaSdk/RULES_OPCUA
@@ -1,5 +1,5 @@
 #*************************************************************************
-# Copyright (c) 2018 ITER Organization.
+# Copyright (c) 2018-2021 ITER Organization.
 # This module is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
@@ -33,13 +33,19 @@ ifeq ($(UASDK_USE_CRYPTO),YES)
 USR_SYS_LIBS_Linux += crypto
 endif
 
+# Debug builds need the d-marker to be set
 # Depending on SDK version, C++ modules may have a 'cpp' suffix
-UASDK_LIBS = $(notdir $(foreach module, $(UASDK_MODULES), \
-$(firstword $(wildcard $(UASDK)/include/$(module)cpp $(UASDK)/include/$(module)))))
+ifeq ($(HOST_OPT),NO)
+D_MARKER = d
+endif
+UASDK_MODS = $(notdir $(foreach module, $(UASDK_MODULES), \
+$(firstword $(wildcard $(UASDK)/include/$(module)cpp \
+$(UASDK)/include/$(module)))))
+UASDK_LIBS = $(addsuffix $(D_MARKER), $(UASDK_MODS))
 
 ifdef OPCUA_NEEDS_INCLUDES
 USR_INCLUDES += -I$(UASDK)/include
-USR_INCLUDES += $(foreach lib, $(UASDK_LIBS),-I$(UASDK)/include/$(lib))
+USR_INCLUDES += $(foreach lib, $(UASDK_MODS),-I$(UASDK)/include/$(lib))
 # SDK libraries are not built with correct RUNPATH - rely on executable
 USR_LDFLAGS_Linux += -Wl,--disable-new-dtags
 endif

--- a/devOpcuaSup/UaSdk/Session.cpp
+++ b/devOpcuaSup/UaSdk/Session.cpp
@@ -17,6 +17,7 @@
 
 #include <epicsThread.h>
 
+#define epicsExportSharedSymbols
 #include "Session.h"
 #include "SessionUaSdk.h"
 

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -319,7 +319,7 @@ SessionUaSdk::processRequests (std::vector<std::shared_ptr<ReadRequest>> &batch)
     ServiceSettings serviceSettings;
     OpcUa_UInt32 id = getTransactionId();
 
-    nodesToRead.create(batch.size());
+    nodesToRead.create(static_cast<OpcUa_UInt32>(batch.size()));
     OpcUa_UInt32 i = 0;
     for (auto c : batch) {
         c->item->getNodeId().copyTo(&nodesToRead[i].NodeId);
@@ -374,7 +374,7 @@ SessionUaSdk::processRequests (std::vector<std::shared_ptr<WriteRequest>> &batch
     ServiceSettings serviceSettings;
     OpcUa_UInt32 id = getTransactionId();
 
-    nodesToWrite.create(batch.size());
+    nodesToWrite.create(static_cast<OpcUa_UInt32>(batch.size()));
     OpcUa_UInt32 i = 0;
     for (auto c : batch) {
         c->item->getNodeId().copyTo(&nodesToWrite[i].NodeId);

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -13,7 +13,7 @@
 
 // Avoid problems on Windows (macros min, max clash with numeric_limits<>)
 #ifdef _WIN32
-#  define NOMINMAX
+#    define NOMINMAX
 #endif
 
 #include <iostream>
@@ -217,14 +217,14 @@ SessionUaSdk::setOption (const std::string &name, const std::string &value)
 
     unsigned int max = 0;
     if (connectInfo.nMaxOperationsPerServiceCall > 0 && readNodesMax > 0) {
-        max = std::min(connectInfo.nMaxOperationsPerServiceCall, readNodesMax);
+        max = std::min<unsigned int>(connectInfo.nMaxOperationsPerServiceCall, readNodesMax);
     } else {
         max = connectInfo.nMaxOperationsPerServiceCall + readNodesMax;
     }
     if (updateReadBatcher) reader.setParams(max, readTimeoutMin, readTimeoutMax);
 
     if (connectInfo.nMaxOperationsPerServiceCall > 0 && writeNodesMax > 0) {
-        max = std::min(connectInfo.nMaxOperationsPerServiceCall, writeNodesMax);
+        max = std::min<unsigned int>(connectInfo.nMaxOperationsPerServiceCall, writeNodesMax);
     } else {
         max = connectInfo.nMaxOperationsPerServiceCall + writeNodesMax;
     }

--- a/devOpcuaSup/UaSdk/Subscription.cpp
+++ b/devOpcuaSup/UaSdk/Subscription.cpp
@@ -12,6 +12,9 @@
 
 #include <errlog.h>
 
+#include <epicsThread.h>
+#include <epicsEvent.h>
+
 #define epicsExportSharedSymbols
 #include "Session.h"
 #include "Subscription.h"

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
@@ -24,6 +24,8 @@
 #include <uasession.h>
 
 #include <errlog.h>
+#include <epicsThread.h>
+#include <epicsEvent.h>
 
 #define epicsExportSharedSymbols
 #include "SubscriptionUaSdk.h"

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
@@ -11,6 +11,11 @@
  *  and example code from the Unified Automation C++ Based OPC UA Client SDK
  */
 
+// Avoid problems on Windows (macros min, max clash with numeric_limits<>)
+#ifdef _WIN32
+#    define NOMINMAX
+#endif
+
 #include <iostream>
 #include <string>
 #include <map>

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
@@ -19,6 +19,7 @@
 #include <uasubscription.h>
 
 #include <epicsTypes.h>
+#include <shareLib.h>
 
 #include "SessionUaSdk.h"
 #include "Subscription.h"

--- a/devOpcuaSup/linkParser.cpp
+++ b/devOpcuaSup/linkParser.cpp
@@ -19,9 +19,11 @@
 #include <algorithm>
 
 #include <dbCommon.h>
+#include <dbAccess.h>
 #include <epicsStdlib.h>
 #include <link.h>
 
+#define epicsExportSharedSymbols
 #include "devOpcua.h"
 #include "linkParser.h"
 #include "opcuaItemRecord.h"

--- a/unitTestApp/src/RequestQueueBatcherTest.cpp
+++ b/unitTestApp/src/RequestQueueBatcherTest.cpp
@@ -231,9 +231,12 @@ protected:
         ~Adder() override { t.exitWait(); }
 
         virtual void run () override {
-            for (unsigned int i = 0; i < no; i++) {
-                parent.addRequests(b, static_cast<menuPriority>(rand() % 3), 1);
-                if (i % 10 == 0) epicsThreadSleep(0.04); // allow context switch
+            unsigned int added = 0;
+            while (added < no) {
+                unsigned int i = std::max<unsigned int>(rand() % 7, no - added);
+                parent.addRequests(b, static_cast<menuPriority>(rand() % 3), i);
+                added += i;
+                epicsThreadSleep(0.02 + 0.001 * (rand() % 23)); // allow context switch
             }
             done.signal();
         }

--- a/unitTestApp/src/RequestQueueBatcherTest.cpp
+++ b/unitTestApp/src/RequestQueueBatcherTest.cpp
@@ -67,7 +67,7 @@ void
 TestDumper::processRequests(std::vector<std::shared_ptr<TestCargo>> &batch)
 {
     noOfBatches++;
-    batchSizes.push_back(batch.size());
+    batchSizes.push_back(static_cast<unsigned int>(batch.size()));
     std::vector<unsigned int> data;
     bool done = false;
 

--- a/unitTestApp/src/RequestQueueBatcherTest.cpp
+++ b/unitTestApp/src/RequestQueueBatcherTest.cpp
@@ -233,7 +233,7 @@ protected:
         virtual void run () override {
             for (unsigned int i = 0; i < no; i++) {
                 parent.addRequests(b, static_cast<menuPriority>(rand() % 3), 1);
-                if (!i % 10) epicsThreadSleep(0.04); // allow context switch
+                if (i % 10 == 0) epicsThreadSleep(0.04); // allow context switch
             }
             done.signal();
         }

--- a/unitTestApp/src/UaSdk/Makefile
+++ b/unitTestApp/src/UaSdk/Makefile
@@ -1,5 +1,5 @@
 #*************************************************************************
-# Copyright (c) 2020 ITER Organization.
+# Copyright (c) 2020-2021 ITER Organization.
 # This module is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
@@ -8,8 +8,12 @@
 
 # This is a Makefile fragment, see unitTestApp/src/Makefile.
 
+DEVSUP_SRC = $(TOP)/devOpcuaSup
+UASDK_SRC = $(DEVSUP_SRC)/UaSdk
+
 SRC_DIRS += $(TESTSRC)/UaSdk
-USR_INCLUDES += -I$(TOP)/devOpcuaSup/UaSdk
+SRC_DIRS += $(DEVSUP_SRC) $(UASDK_SRC)
+USR_INCLUDES += -I$(UASDK_SRC)
 
 #==================================================
 # Build tests executables
@@ -20,5 +24,8 @@ GTESTS += RangeCheckTest
 
 GTESTPROD_HOST += NamespaceMapTest
 NamespaceMapTest_SRCS += NamespaceMapTest.cpp
-NamespaceMapTest_LIBS += opcua
+NamespaceMapTest_LIBS_DEFAULT += opcua
+NamespaceMapTest_OBJS_WIN32 += SessionUaSdk SubscriptionUaSdk ItemUaSdk DataElementUaSdk
+NamespaceMapTest_OBJS_WIN32 += RecordConnector Subscription
+NamespaceMapTest_LIBS_WIN32 += $(EPICS_BASE_IOC_LIBS)
 GTESTS += NamespaceMapTest

--- a/unitTestApp/src/UaSdk/RangeCheckTest.cpp
+++ b/unitTestApp/src/UaSdk/RangeCheckTest.cpp
@@ -47,7 +47,7 @@ TEST(RangeCheckTest, ToSByte) {
     EXPECT_FALSE(isWithinRange<OpcUa_SByte>(static_cast<epicsUInt32>(128))) << "SByte<-UInt32: 128 not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_SByte>(static_cast<epicsUInt32>(4294967295))) << "SByte<-UInt32: MAX (2^32-1) not detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_SByte>(static_cast<epicsInt32>(-2147483648))) << "SByte<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_SByte>(static_cast<epicsInt32>(-2147483648ll))) << "SByte<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_SByte>(static_cast<epicsInt32>(-129))) << "SByte<-Int32: -129 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_SByte>(static_cast<epicsInt32>(-128))) << "SByte<-Int32: -128 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_SByte>(static_cast<epicsInt32>(0))) << "SByte<-Int32: 0 detected as out of range";
@@ -115,7 +115,7 @@ TEST(RangeCheckTest, ToByte) {
     EXPECT_FALSE(isWithinRange<OpcUa_Byte>(static_cast<epicsUInt32>(256))) << "Byte<-UInt32: 256 not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Byte>(static_cast<epicsUInt32>(4294967295))) << "Byte<-UInt32: MAX (2^32-1) not detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_Byte>(static_cast<epicsInt32>(-2147483648))) << "Byte<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_Byte>(static_cast<epicsInt32>(-2147483648ll))) << "Byte<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Byte>(static_cast<epicsInt32>(-1))) << "Byte<-Int32: -1 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Byte>(static_cast<epicsInt32>(0))) << "Byte<-Int32: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Byte>(static_cast<epicsInt32>(255))) << "Byte<-Int32: 255 detected as out of range";
@@ -175,7 +175,7 @@ TEST(RangeCheckTest, ToInt16) {
     EXPECT_FALSE(isWithinRange<OpcUa_Int16>(static_cast<epicsUInt32>(32768))) << "Int16<-UInt32: 32768 not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Int16>(static_cast<epicsUInt32>(4294967295))) << "Int16<-UInt32: MAX (2^32-1) not detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_Int16>(static_cast<epicsInt32>(-2147483648))) << "Int16<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_Int16>(static_cast<epicsInt32>(-2147483648ll))) << "Int16<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Int16>(static_cast<epicsInt32>(-32769))) << "Int16<-Int32: -32769 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int16>(static_cast<epicsInt32>(-32768))) << "Int16<-Int32: -32768 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int16>(static_cast<epicsInt32>(0))) << "Int16<-Int32: 0 detected as out of range";
@@ -240,7 +240,7 @@ TEST(RangeCheckTest, ToUInt16) {
     EXPECT_FALSE(isWithinRange<OpcUa_UInt16>(static_cast<epicsUInt32>(65536))) << "UInt16<-UInt32: 65536 not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_UInt16>(static_cast<epicsUInt32>(4294967295))) << "UInt16<-UInt32: MAX (2^32-1) not detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_UInt16>(static_cast<epicsInt32>(-2147483648))) << "UInt16<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_UInt16>(static_cast<epicsInt32>(-2147483648ll))) << "UInt16<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_UInt16>(static_cast<epicsInt32>(-1))) << "UInt16<-Int32: -1 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt16>(static_cast<epicsInt32>(0))) << "UInt16<-Int32: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt16>(static_cast<epicsInt32>(65535))) << "UInt16<-Int32: 65535 detected as out of range";
@@ -299,7 +299,7 @@ TEST(RangeCheckTest, ToInt32) {
     EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsUInt32>(2147483648))) << "Int32<-UInt32: 2^31 not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsUInt32>(4294967295))) << "Int32<-UInt32: MAX (2^32-1) not detected as out of range";
 
-    EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt32>(-2147483648))) << "Int32<-Int32: MIN (-2^31) detected as out of range";
+    EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt32>(-2147483648ll))) << "Int32<-Int32: MIN (-2^31) detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt32>(0))) << "Int32<-Int32: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt32>(2147483647))) << "Int32<-Int32: MAX (2^31-1) detected as out of range";
 
@@ -309,8 +309,8 @@ TEST(RangeCheckTest, ToInt32) {
     EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsUInt64>(18446744073709551615ull))) << "Int32<-UInt64: MAX (2^64-1) not detected as out of range";
 
     EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(-9223372036854775807ll-1))) << "Int32<-Int64: MIN (-2^63) not detected as out of range";
-    EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(-2147483649))) << "Int32<-Int64: -2^31-1 not detected as out of range";
-    EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(-2147483648))) << "Int32<-Int64: -2^31 detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(-2147483649ll))) << "Int32<-Int64: -2^31-1 not detected as out of range";
+    EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(-2147483648ll))) << "Int32<-Int64: -2^31 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(0))) << "Int32<-Int64: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(2147483647))) << "Int32<-Int64: 2^31-1 detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_Int32>(static_cast<epicsInt64>(2147483648))) << "Int32<-Int64: 2^31 not detected as out of range";
@@ -361,7 +361,7 @@ TEST(RangeCheckTest, ToUInt32) {
     EXPECT_TRUE(isWithinRange<OpcUa_UInt32>(static_cast<epicsUInt32>(65536))) << "UInt32<-UInt32: 65536 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt32>(static_cast<epicsUInt32>(4294967295))) << "UInt32<-UInt32: MAX (2^32-1) detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_UInt32>(static_cast<epicsInt32>(-2147483648))) << "UInt32<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_UInt32>(static_cast<epicsInt32>(-2147483648ll))) << "UInt32<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_UInt32>(static_cast<epicsInt32>(-1))) << "UInt32<-Int32: -1 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt32>(static_cast<epicsInt32>(0))) << "UInt32<-Int32: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt32>(static_cast<epicsInt32>(65536))) << "UInt32<-Int32: 65536 detected as out of range";
@@ -419,7 +419,7 @@ TEST(RangeCheckTest, ToInt64) {
     EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsUInt32>(2147483648))) << "Int64<-UInt32: 2^31 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsUInt32>(4294967295))) << "Int64<-UInt32: MAX (2^32-1) detected as out of range";
 
-    EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsInt64>(-2147483648))) << "Int64<-Int64: MIN (-2^31) detected as out of range";
+    EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsInt64>(-2147483648ll))) << "Int64<-Int64: MIN (-2^31) detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsInt64>(0))) << "Int64<-Int64: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Int64>(static_cast<epicsInt64>(2147483647))) << "Int64<-Int64: MAX (2^31-1) detected as out of range";
 
@@ -479,7 +479,7 @@ TEST(RangeCheckTest, ToUInt64) {
     EXPECT_TRUE(isWithinRange<OpcUa_UInt64>(static_cast<epicsUInt32>(65536))) << "UInt64<-UInt32: 65536 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt64>(static_cast<epicsUInt32>(4294967295))) << "UInt64<-UInt32: MAX (2^32-1) detected as out of range";
 
-    EXPECT_FALSE(isWithinRange<OpcUa_UInt64>(static_cast<epicsInt32>(-2147483648))) << "UInt64<-Int32: MIN (-2^31) not detected as out of range";
+    EXPECT_FALSE(isWithinRange<OpcUa_UInt64>(static_cast<epicsInt32>(-2147483648ll))) << "UInt64<-Int32: MIN (-2^31) not detected as out of range";
     EXPECT_FALSE(isWithinRange<OpcUa_UInt64>(static_cast<epicsInt32>(-1))) << "UInt64<-Int32: -1 not detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt64>(static_cast<epicsInt32>(0))) << "UInt64<-Int32: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_UInt64>(static_cast<epicsInt32>(2147483647))) << "UInt64<-Int32: MAX (2^31-1) detected as out of range";
@@ -534,7 +534,7 @@ TEST(RangeCheckTest, ToFloat) {
     EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsUInt32>(2147483648))) << "Float<-UInt32: 2^31 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsUInt32>(4294967295))) << "Float<-UInt32: MAX (2^32-1) detected as out of range";
 
-    EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsInt64>(-2147483648))) << "Float<-Int64: MIN (-2^31) detected as out of range";
+    EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsInt64>(-2147483648ll))) << "Float<-Int64: MIN (-2^31) detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsInt64>(0))) << "Float<-Int64: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Float>(static_cast<epicsInt64>(2147483647))) << "Float<-Int64: MAX (2^31-1) detected as out of range";
 
@@ -581,7 +581,7 @@ TEST(RangeCheckTest, ToDouble) {
     EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsUInt32>(2147483648))) << "Double<-UInt32: 2^31 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsUInt32>(4294967295))) << "Double<-UInt32: MAX (2^32-1) detected as out of range";
 
-    EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsInt64>(-2147483648))) << "Double<-Int64: MIN (-2^31) detected as out of range";
+    EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsInt64>(-2147483648ll))) << "Double<-Int64: MIN (-2^31) detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsInt64>(0))) << "Double<-Int64: 0 detected as out of range";
     EXPECT_TRUE(isWithinRange<OpcUa_Double>(static_cast<epicsInt64>(2147483647))) << "Double<-Int64: MAX (2^31-1) detected as out of range";
 


### PR DESCRIPTION
This branch contains a bunch of different changes required for successfully building the Device Support module on Windows.

- DLL import/export decorations
- Fixes of compiler warnings (`size_t` is 64bit on Windows)
- Naming of debug-type libraries on Windows using the "d-marker"
- Different locations of third-party libraries within the UA SDK bundle (depending on version)
- Different names of the openssl libraries within the UA SDK bundle (depending on openssl version)

Fixes #88. Thanks a lot to @nugatritter (Carsten Winkler) for his extensive help and testing.