### PR TITLE
Improve opcuaShow... routines

### DIFF
--- a/devOpcuaSup/RecordConnector.cpp
+++ b/devOpcuaSup/RecordConnector.cpp
@@ -188,13 +188,16 @@ RecordConnector::requestRecordProcessing (const ProcessReason reason)
 RecordConnector *
 RecordConnector::findRecordConnector (const std::string &name)
 {
+    RecordConnector *result;
     DBENTRY entry;
     dbInitEntry(pdbbase, &entry);
     if (dbFindRecord(&entry, name.c_str())) {
         dbFinishEntry(&entry);
         return nullptr;
     }
-    return static_cast<RecordConnector *>(static_cast<dbCommon *>(entry.precnode->precord)->dpvt);
+    result = static_cast<RecordConnector *>(static_cast<dbCommon *>(entry.precnode->precord)->dpvt);
+    dbFinishEntry(&entry);
+    return result;
 }
 
 } // namespace DevOpcua

--- a/devOpcuaSup/RecordConnector.cpp
+++ b/devOpcuaSup/RecordConnector.cpp
@@ -17,6 +17,7 @@
 
 #include <link.h>
 #include <shareLib.h>
+#include <epicsString.h>
 #include <epicsThread.h>
 #include <callback.h>
 #include <recSup.h>
@@ -196,6 +197,51 @@ RecordConnector::findRecordConnector (const std::string &name)
         return nullptr;
     }
     result = static_cast<RecordConnector *>(static_cast<dbCommon *>(entry.precnode->precord)->dpvt);
+    dbFinishEntry(&entry);
+    return result;
+}
+
+std::set<RecordConnector *>
+RecordConnector::glob(const std::string &pattern)
+{
+    DBENTRY entry;
+    long status;
+    std::set<RecordConnector *> result;
+
+    dbInitEntry(pdbbase, &entry);
+    status = dbFirstRecordType(&entry);
+    while (!status) {
+        status = dbFirstRecord(&entry);
+        while (!status) {
+            if (!(dbFindField(&entry, "RTYP") || strcmp(dbGetString(&entry), "opcuaItem"))
+                || !(dbFindField(&entry, "DTYP") || strcmp(dbGetString(&entry), "OPCUA"))) {
+                char *pname = dbGetRecordName(&entry);
+                RecordConnector *rc = static_cast<RecordConnector *>(
+                    static_cast<dbCommon *>(entry.precnode->precord)->dpvt);
+                if (rc) {
+                    bool match = false;
+                    if (epicsStrGlobMatch(pname, pattern.c_str())) {
+                        match = true;
+                    } else if (rc->plinkinfo) {
+                        if (rc->plinkinfo->identifierIsNumeric) {
+                            if (epicsStrGlobMatch(std::to_string(rc->plinkinfo->identifierNumber)
+                                                      .c_str(),
+                                                  pattern.c_str()))
+                                match = true;
+                        } else {
+                            if (epicsStrGlobMatch(rc->plinkinfo->identifierString.c_str(),
+                                                  pattern.c_str()))
+                                match = true;
+                        }
+                    }
+                    if (match)
+                        result.insert(rc);
+                }
+            }
+            status = dbNextRecord(&entry);
+        }
+        status = dbNextRecordType(&entry);
+    }
     dbFinishEntry(&entry);
     return result;
 }

--- a/devOpcuaSup/RecordConnector.h
+++ b/devOpcuaSup/RecordConnector.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <cstddef>
 #include <iostream>
+#include <set>
 
 #include <epicsMutex.h>
 #include <dbCommon.h>
@@ -112,9 +113,17 @@ public:
      * @brief Find record connector by record name.
      *
      * @param name  record name
-     * @return record connector (nullptr if record not found)
+     * @return pointer to record connector (nullptr if record not found)
      */
     static RecordConnector *findRecordConnector(const std::string &name);
+
+    /**
+     * @brief Find record connector with record names matching a glob pattern.
+     *
+     * @param pattern  record name pattern to match
+     * @return set of record connector pointers
+     */
+    static std::set<RecordConnector *> glob(const std::string &pattern);
 
     epicsMutex lock;
     std::unique_ptr<linkInfo> plinkinfo;

--- a/devOpcuaSup/Registry.h
+++ b/devOpcuaSup/Registry.h
@@ -17,6 +17,7 @@
 
 #include <epicsMutex.h>
 #include <epicsGuard.h>
+#include <epicsString.h>
 
 namespace DevOpcua {
 
@@ -119,6 +120,27 @@ public:
     contains(const std::string &name)
     {
         return !!find(name);
+    }
+
+    /**
+     * @brief Return objects with names matching a glob pattern.
+     *
+     * Template parameter B is the base class of T that will be used
+     * in the returned set.
+     *
+     * @param pattern  name pattern to match
+     *
+     * @return  vector of pointers to matching objects
+     */
+    template<class B>
+    std::set<B *> glob(const std::string &pattern)
+    {
+        std::set<B *> result;
+        for (auto &it : registry) {
+            if (epicsStrGlobMatch(it.first.c_str(), pattern.c_str()))
+                result.insert(static_cast<B *>(it.second));
+        }
+        return result;
     }
 
     // STL standards: size() and iterators

--- a/devOpcuaSup/Session.h
+++ b/devOpcuaSup/Session.h
@@ -14,6 +14,7 @@
 #define DEVOPCUA_SESSION_H
 
 #include <string>
+#include <set>
 
 #include <shareLib.h>
 
@@ -149,6 +150,15 @@ public:
      * @return  pointer to session, nullptr if not found
      */
     static Session *find(const std::string &name);
+
+    /**
+     * @brief Find sessions with names matching a glob pattern.
+     *
+     * @param pattern  session name pattern to match
+     *
+     * @return  set of pointers to matching sessions
+     */
+    static std::set<Session *> glob(const std::string &pattern);
 
     /**
      * @brief Print help text for available options.

--- a/devOpcuaSup/Subscription.h
+++ b/devOpcuaSup/Subscription.h
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <map>
+#include <set>
 
 #include <epicsTypes.h>
 #include <shareLib.h>
@@ -87,6 +88,15 @@ public:
      * @return  pointer to subscription, nullptr if not found
      */
     static Subscription *find(const std::string &name);
+
+    /**
+     * @brief Find subscriptions with names matching a glob pattern.
+     *
+     * @param pattern  subscription name pattern to match
+     *
+     * @return  set of pointers to matching subscriptions
+     */
+    static std::set<Subscription *> glob(const std::string &pattern);
 
     const std::string name; /**< subscription name */
     int debug;              /**< debug verbosity level */

--- a/devOpcuaSup/UaSdk/Session.cpp
+++ b/devOpcuaSup/UaSdk/Session.cpp
@@ -56,6 +56,12 @@ Session::find(const std::string &name)
     return SessionUaSdk::find(name);
 }
 
+std::set<Session *>
+Session::glob(const std::string &pattern)
+{
+    return SessionUaSdk::glob(pattern);
+}
+
 void
 Session::showAll (const int level)
 {

--- a/devOpcuaSup/UaSdk/SessionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.h
@@ -17,11 +17,13 @@
 #include <algorithm>
 #include <vector>
 #include <memory>
+#include <set>
 
 #include <uabase.h>
 #include <uaclientsdk.h>
 #include <uasession.h>
 
+#include <epicsString.h>
 #include <epicsMutex.h>
 #include <epicsTypes.h>
 #include <initHooks.h>
@@ -165,6 +167,12 @@ public:
     find(const std::string &name)
     {
         return sessions.find(name);
+    }
+
+    static std::set<Session *>
+    glob(const std::string &pattern)
+    {
+        return sessions.glob<Session>(pattern);
     }
 
     /**

--- a/devOpcuaSup/UaSdk/Subscription.cpp
+++ b/devOpcuaSup/UaSdk/Subscription.cpp
@@ -44,6 +44,12 @@ Subscription::find (const std::string &name)
     return SubscriptionUaSdk::find(name);
 }
 
+std::set<Subscription *>
+Subscription::glob(const std::string &pattern)
+{
+    return SubscriptionUaSdk::glob(pattern);
+}
+
 void
 Subscription::showAll (const int level)
 {

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
@@ -14,10 +14,14 @@
 #ifndef DEVOPCUA_SUBSCRIPTIONUASDK_H
 #define DEVOPCUA_SUBSCRIPTIONUASDK_H
 
+#include <vector>
+#include <set>
+
 #include <uabase.h>
 #include <uaclientsdk.h>
 #include <uasubscription.h>
 
+#include <epicsString.h>
 #include <epicsTypes.h>
 #include <shareLib.h>
 
@@ -82,6 +86,12 @@ public:
     find(const std::string &name)
     {
         return subscriptions.find(name);
+    }
+
+    static std::set<Subscription *>
+    glob(const std::string &pattern)
+    {
+        return subscriptions.glob<Subscription>(pattern);
     }
 
     /**

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -250,6 +250,9 @@ static const iocshFuncDef opcuaShowSessionFuncDef = {"opcuaShowSession", 2, opcu
 static
 void opcuaShowSessionCallFunc (const iocshArgBuf *args)
 {
+    std::cerr << "DEPRECATION WARNING: opcuaShowSession is obsolete; use the improved opcuaShow "
+                 "command instead (that supports glob patterns)."
+              << std::endl;
     try {
         if (args[0].sval == nullptr || args[0].sval[0] == '\0') {
             Session::showAll(args[1].ival);
@@ -431,6 +434,10 @@ static const iocshFuncDef opcuaShowSubscriptionFuncDef = {"opcuaShowSubscription
 static
 void opcuaShowSubscriptionCallFunc (const iocshArgBuf *args)
 {
+    std::cerr
+        << "DEPRECATION WARNING: opcuaShowSubscription is obsolete; use the improved opcuaShow "
+           "command instead (that supports glob patterns)."
+        << std::endl;
     try {
         if (args[0].sval == nullptr || args[0].sval[0] == '\0') {
             Subscription::showAll(args[1].ival);
@@ -474,6 +481,9 @@ static const iocshFuncDef opcuaShowDataFuncDef = {"opcuaShowData", 2, opcuaShowD
 static
 void opcuaShowDataCallFunc (const iocshArgBuf *args)
 {
+    std::cerr << "DEPRECATION WARNING: opcuaShowData is obsolete; use the improved opcuaShow "
+                 "command instead (that supports glob patterns)."
+              << std::endl;
     try {
         if (args[0].sval == NULL || args[0].sval[0] == '\0') {
             errlogPrintf("missing argument #1 (record name)\n");


### PR DESCRIPTION
- Replace specific routines `opcuaShowSession`, `opcuaShowSubscription` and `opcuaShowData` with a single `opcuaShow` routine that searches sessions, subscriptions, records and item names.
- Support glob patterns.