### PR TITLE
Add write-on-change feature to opcuaItemRecord

### DIFF
--- a/devOpcuaSup/Item.h
+++ b/devOpcuaSup/Item.h
@@ -66,6 +66,11 @@ public:
     virtual void requestWrite() = 0;
 
     /**
+     * @brief Schedule a write request if item data is "dirty".
+     */
+    virtual void requestWriteIfDirty() = 0;
+
+    /**
      * @brief Get the cached status of the last item operation.
      *
      * @param[out] code  OPC UA status code

--- a/devOpcuaSup/RecordConnector.h
+++ b/devOpcuaSup/RecordConnector.h
@@ -101,6 +101,16 @@ public:
     const char *getRecordName() const { return prec->name; }
     const char *getRecordType() const { return prec->rdes->name; }
     menuPriority getRecordPriority() const { return static_cast<menuPriority>(prec->prio); }
+
+    menuWoc
+    woc() const
+    {
+        if (plinkinfo->isItemRecord)
+            return static_cast<menuWoc>(reinterpret_cast<opcuaItemRecord *>(prec)->woc);
+        else
+            return static_cast<menuWoc>(0);
+    }
+
     LinkOptionBini bini() const {
         if (plinkinfo->isItemRecord)
             return static_cast<LinkOptionBini>(reinterpret_cast<opcuaItemRecord*>(prec)->bini);

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -50,6 +50,7 @@ DataElementUaSdk::DataElementUaSdk (const std::string &name,
     , pitem(item)
     , mapped(false)
     , incomingQueue(pconnector->plinkinfo->clientQueueSize, pconnector->plinkinfo->discardOldest)
+    , outgoingLock(pitem->dataTreeWriteLock)
     , isdirty(false)
 {}
 
@@ -59,6 +60,7 @@ DataElementUaSdk::DataElementUaSdk (const std::string &name,
     , pitem(item)
     , mapped(false)
     , incomingQueue(0ul)
+    , outgoingLock(pitem->dataTreeWriteLock)
     , isdirty(false)
 {}
 

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -828,26 +828,26 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
     case OpcUaType_String:
     { // Scope of Guard G
         Guard G(outgoingLock);
-        isdirty = true;
         outgoingData.setString(static_cast<UaString>(value));
+        markAsDirty();
         break;
     }
     case OpcUaType_Boolean:
     { // Scope of Guard G
         Guard G(outgoingLock);
-        isdirty = true;
         if (strchr("YyTt1", *value))
             outgoingData.setBoolean(true);
         else
             outgoingData.setBoolean(false);
+        markAsDirty();
         break;
     }
     case OpcUaType_Byte:
         ul = strtoul(value, nullptr, 0);
         if (isWithinRange<OpcUa_Byte>(ul)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setByte(static_cast<OpcUa_Byte>(ul));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -857,8 +857,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         l = strtol(value, nullptr, 0);
         if (isWithinRange<OpcUa_SByte>(l)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setSByte(static_cast<OpcUa_SByte>(l));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -868,8 +868,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         ul = strtoul(value, nullptr, 0);
         if (isWithinRange<OpcUa_UInt16>(ul)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setUInt16(static_cast<OpcUa_UInt16>(ul));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -879,8 +879,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         l = strtol(value, nullptr, 0);
         if (isWithinRange<OpcUa_Int16>(l)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setInt16(static_cast<OpcUa_Int16>(l));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -890,8 +890,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         ul = strtoul(value, nullptr, 0);
         if (isWithinRange<OpcUa_UInt32>(ul)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setUInt32(static_cast<OpcUa_UInt32>(ul));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -901,8 +901,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         l = strtol(value, nullptr, 0);
         if (isWithinRange<OpcUa_Int32>(l)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setInt32(static_cast<OpcUa_Int32>(l));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -912,8 +912,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         ul = strtoul(value, nullptr, 0);
         if (isWithinRange<OpcUa_UInt64>(ul)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setUInt64(static_cast<OpcUa_UInt64>(ul));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -923,8 +923,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         l = strtol(value, nullptr, 0);
         if (isWithinRange<OpcUa_Int64>(l)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setInt64(static_cast<OpcUa_Int64>(l));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -934,8 +934,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
         d = strtod(value, nullptr);
         if (isWithinRange<OpcUa_Float>(d)) {
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setFloat(static_cast<OpcUa_Float>(d));
+            markAsDirty();
         } else {
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
@@ -945,8 +945,8 @@ DataElementUaSdk::writeScalar (const char *value, const epicsUInt32 len, dbCommo
     {
         d = strtod(value, nullptr);
         Guard G(outgoingLock);
-        isdirty = true;
         outgoingData.setDouble(static_cast<OpcUa_Double>(d));
+        markAsDirty();
         break;
     }
     default:
@@ -1012,8 +1012,8 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
         }
         { // Scope of Guard G
             Guard G(outgoingLock);
-            isdirty = true;
             UaVariant_set(outgoingData, arr);
+            markAsDirty();
         }
 
         dbgWriteArray(num, epicsTypeString(**value));
@@ -1048,8 +1048,8 @@ DataElementUaSdk::writeArray<epicsUInt8, UaByteArray, OpcUa_Byte> (const epicsUI
         UaByteArray arr(reinterpret_cast<const char *>(value), static_cast<OpcUa_Int32>(num));
         { // Scope of Guard G
             Guard G(outgoingLock);
-            isdirty = true;
             UaVariant_set(outgoingData, arr);
+            markAsDirty();
         }
 
         dbgWriteArray(num, epicsTypeString(*value));

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -1089,7 +1089,7 @@ private:
     bool mapped;                             /**< child name to index mapping done */
     UpdateQueue<UpdateUaSdk> incomingQueue;  /**< queue of incoming values */
     UaVariant incomingData;                  /**< cache of latest incoming value */
-    epicsMutex outgoingLock;                 /**< data lock for outgoing value */
+    epicsMutex &outgoingLock;                /**< data lock for outgoing value */
     UaVariant outgoingData;                  /**< cache of latest outgoing value */
     bool isdirty;                            /**< outgoing value has been (or needs to be) updated */
 };

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -672,6 +672,12 @@ private:
                                   std::shared_ptr<DataElementUaSdk> pelem);
     // Structure always returns true to ensure full traversal
     bool isDirty() const { return isdirty || !isleaf; }
+    void
+    markAsDirty()
+    {
+        isdirty = true;
+        pitem->markAsDirty();
+    }
 
     // Get the time stamp from the incoming object
     const epicsTime &getIncomingTimeStamp() const {
@@ -904,18 +910,18 @@ private:
         case OpcUaType_Boolean:
         { // Scope of Guard G
             Guard G(outgoingLock);
-            isdirty = true;
             if (value == 0)
                 outgoingData.setBoolean(false);
             else
                 outgoingData.setBoolean(true);
+            markAsDirty();
             break;
         }
         case OpcUaType_Byte:
             if (isWithinRange<OpcUa_Byte>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setByte(static_cast<OpcUa_Byte>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -924,8 +930,8 @@ private:
         case OpcUaType_SByte:
             if (isWithinRange<OpcUa_SByte>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setSByte(static_cast<OpcUa_SByte>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -934,8 +940,8 @@ private:
         case OpcUaType_UInt16:
             if (isWithinRange<OpcUa_UInt16>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setUInt16(static_cast<OpcUa_UInt16>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -944,8 +950,8 @@ private:
         case OpcUaType_Int16:
             if (isWithinRange<OpcUa_Int16>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setInt16(static_cast<OpcUa_Int16>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -954,8 +960,8 @@ private:
         case OpcUaType_UInt32:
             if (isWithinRange<OpcUa_UInt32>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setUInt32(static_cast<OpcUa_UInt32>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -964,8 +970,8 @@ private:
         case OpcUaType_Int32:
             if (isWithinRange<OpcUa_Int32>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setInt32(static_cast<OpcUa_Int32>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -974,8 +980,8 @@ private:
         case OpcUaType_UInt64:
             if (isWithinRange<OpcUa_UInt64>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setUInt64(static_cast<OpcUa_UInt64>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -984,8 +990,8 @@ private:
         case OpcUaType_Int64:
             if (isWithinRange<OpcUa_Int64>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setInt64(static_cast<OpcUa_Int64>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -994,8 +1000,8 @@ private:
         case OpcUaType_Float:
             if (isWithinRange<OpcUa_Float>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setFloat(static_cast<OpcUa_Float>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -1004,8 +1010,8 @@ private:
         case OpcUaType_Double:
             if (isWithinRange<OpcUa_Double>(value)) {
                 Guard G(outgoingLock);
-                isdirty = true;
                 outgoingData.setDouble(static_cast<OpcUa_Double>(value));
+                markAsDirty();
             } else {
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
@@ -1014,8 +1020,8 @@ private:
         case OpcUaType_String:
         { // Scope of Guard G
             Guard G(outgoingLock);
-            isdirty = true;
             outgoingData.setString(static_cast<UaString>(std::to_string(value).c_str()));
+            markAsDirty();
             break;
         }
         default:
@@ -1065,8 +1071,8 @@ private:
             CT arr(static_cast<OpcUa_Int32>(num), val);
             { // Scope of Guard G
                 Guard G(outgoingLock);
-                isdirty = true;
                 UaVariant_set(outgoingData, arr);
+                markAsDirty();
             }
 
             dbgWriteArray(num, epicsTypeString(*value));

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -46,6 +46,7 @@ ItemUaSdk::ItemUaSdk(const linkInfo &info)
     , revisedSamplingInterval(0.0)
     , revisedQueueSize(0)
     , dataTree(this)
+    , dataTreeDirty(false)
     , lastStatus(OpcUa_BadServerNotConnected)
     , lastReason(ProcessReason::connectionLoss)
     , connState(ConnectionStatus::down)
@@ -94,6 +95,7 @@ ItemUaSdk::show (int level) const
     std::cout << " record=" << recConnector->getRecordName()
               << " state=" << connectionStatusString(connState)
               << " status=" << UaStatus(lastStatus).toString().toUtf8()
+              << " dataDirty=" << (dataTreeDirty ? "y" : "n")
               << " context=" << linkinfo.subscription
               << "@" << session->getName()
               << " sampling=" << revisedSamplingInterval
@@ -123,23 +125,15 @@ int ItemUaSdk::debug() const
     return recConnector->debug();
 }
 
-//FIXME: in case of itemRecord there might be no rootElement
-const UaVariant &
-ItemUaSdk::getOutgoingData() const
-{
-    if (auto pd = dataTree.root().lock()) {
-        return pd->getOutgoingData();
-    } else {
-        throw std::runtime_error(SB() << "stale pointer to root data element");
-    }
-}
-
 void
-ItemUaSdk::clearOutgoingData()
+ItemUaSdk::copyAndClearOutgoingData(_OpcUa_WriteValue &wvalue)
 {
+    Guard G(dataTreeWriteLock);
     if (auto pd = dataTree.root().lock()) {
+        pd->getOutgoingData().copyTo(&wvalue.Value.Value);
         pd->clearOutgoingData();
     }
+    dataTreeDirty = false;
 }
 
 epicsTime
@@ -204,6 +198,19 @@ ItemUaSdk::setIncomingEvent(const ProcessReason reason)
 
     if (linkinfo.isItemRecord)
         recConnector->requestRecordProcessing(reason);
+}
+
+void
+ItemUaSdk::markAsDirty()
+{
+    if (recConnector->plinkinfo->isItemRecord) {
+        Guard G(dataTreeWriteLock);
+        if (!dataTreeDirty) {
+            dataTreeDirty = true;
+            if (recConnector->woc() == menuWocIMMEDIATE)
+                recConnector->requestRecordProcessing(ProcessReason::writeRequest);
+        }
+    }
 }
 
 void

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -80,6 +80,14 @@ ItemUaSdk::rebuildNodeId ()
 }
 
 void
+ItemUaSdk::requestWriteIfDirty()
+{
+    Guard G(dataTreeWriteLock);
+    if (dataTreeDirty)
+        recConnector->requestRecordProcessing(ProcessReason::writeRequest);
+}
+
+void
 ItemUaSdk::show (int level) const
 {
     std::cout << "item"

--- a/devOpcuaSup/UaSdk/ItemUaSdk.h
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.h
@@ -71,6 +71,12 @@ public:
     virtual void requestWrite() override { session->requestWrite(*this); }
 
     /**
+     * @brief Schedule a write request if item data is "dirty".
+     * See DevOpcua::Item::requestWriteIfDirty
+     */
+    virtual void requestWriteIfDirty() override;
+
+    /**
      * @brief Print configuration and status. See DevOpcua::Item::show
      */
     virtual void show(int level) const override;

--- a/devOpcuaSup/UaSdk/ItemUaSdk.h
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.h
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <statuscode.h>
+#include <opcua_types.h>
 #include <opcua_builtintypes.h>
 #include <uastructuredefinition.h>
 
@@ -149,24 +150,14 @@ public:
     { return session->structureDefinition(dataTypeId); }
 
     /**
-     * @brief Get the outgoing data value.
+     * @brief Copy out then discard the outgoing data value.
      *
      * Called from the OPC UA client worker thread when data is being
      * assembled in OPC UA session for sending.
-     */
-    const UaVariant &getOutgoingData() const;
-
-    /**
-     * @brief Clear (discard) the current outgoing data.
      *
-     * Called by the low level connection (OPC UA session)
-     * after it is done accessing the data in the context of sending.
-     *
-     * In case an implementation uses a queue, this should remove the
-     * oldest element from the queue, allowing access to the next element
-     * with the next send.
+     * @param[out] wvalue reference to WriteValue (target of copy)
      */
-    void clearOutgoingData();
+    void copyAndClearOutgoingData(_OpcUa_WriteValue &wvalue);
 
     /**
      * @brief Push an incoming data value down the root element.
@@ -188,6 +179,11 @@ public:
      * @param reason  reason for this value update
      */
     void setIncomingEvent(ProcessReason reason);
+
+    /**
+     * @brief Mark the item as dirty and set up itemRecord processing.
+     */
+    void markAsDirty();
 
     /**
      * @brief Setter for the revised sampling interval.
@@ -225,6 +221,8 @@ private:
     OpcUa_Double revisedSamplingInterval;  /**< server-revised sampling interval */
     OpcUa_UInt32 revisedQueueSize;         /**< server-revised queue size */
     ElementTree<DataElementUaSdk, ItemUaSdk> dataTree; /**< data element tree */
+    epicsMutex dataTreeWriteLock;           /**< lock for dirty flag */
+    bool dataTreeDirty;                    /**< true if any element has been modified */
     UaStatusCode lastStatus;               /**< status code of most recent service */
     ProcessReason lastReason;              /**< most recent processing reason */
     ConnectionStatus connState;            /**< Connection state of the item */

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -430,8 +430,7 @@ SessionUaSdk::requestWrite (ItemUaSdk &item)
 {
     auto cargo = std::make_shared<WriteRequest>();
     cargo->item = &item;
-    item.getOutgoingData().copyTo(&cargo->wvalue.Value.Value);
-    item.clearOutgoingData();
+    item.copyAndClearOutgoingData(cargo->wvalue);
     writer.pushRequest(cargo, item.recConnector->getRecordPriority());
 }
 

--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -128,6 +128,8 @@ special (DBADDR *paddr, int after)
             *preason = ProcessReason::writeRequest;
         } else if (fieldIndex == opcuaItemRecordREAD) {
             *preason = ProcessReason::readRequest;
+        } else if (fieldIndex == opcuaItemRecordWOC) {
+            //TODO: write if dirty and switching to auto
         }
     }
 

--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -123,13 +123,14 @@ special (DBADDR *paddr, int after)
 
     if (paddr->special == SPC_MOD) {
         int fieldIndex = dbGetFieldIndex(paddr);
-        auto preason = &(reinterpret_cast<RecordConnector *>(paddr->precord->dpvt)->reason);
+        auto pcon = reinterpret_cast<RecordConnector *>(paddr->precord->dpvt);
         if (fieldIndex == opcuaItemRecordWRITE) {
-            *preason = ProcessReason::writeRequest;
+            pcon->reason = ProcessReason::writeRequest;
         } else if (fieldIndex == opcuaItemRecordREAD) {
-            *preason = ProcessReason::readRequest;
+            pcon->reason = ProcessReason::readRequest;
         } else if (fieldIndex == opcuaItemRecordWOC) {
-            //TODO: write if dirty and switching to auto
+            if (reinterpret_cast<opcuaItemRecord *>(paddr->precord)->woc == menuWocIMMEDIATE)
+                pcon->pitem->requestWriteIfDirty();
         }
     }
 

--- a/devOpcuaSup/opcuaItemRecord.dbd
+++ b/devOpcuaSup/opcuaItemRecord.dbd
@@ -11,6 +11,12 @@ menu(menuBini) {
         choice(menuBiniWRITE, "write")
 }
 
+# Menu for 'woc' parameter/field
+menu(menuWoc) {
+        choice(menuWocMANUAL, "manual")
+        choice(menuWocIMMEDIATE, "immediate")
+}
+
 recordtype(opcuaItem) {
     include "dbCommon.dbd"
     field(VAL,DBF_ULONG) {
@@ -70,5 +76,12 @@ recordtype(opcuaItem) {
     field(STATTEXT,DBF_STRING) {
         prompt("OPC UA status string")
         size(41)
+    }
+    field(WOC,DBF_MENU) {
+        prompt("Write-on-change mode")
+        promptgroup("30 - Action")
+        interest(1)
+        menu(menuWoc)
+        special(SPC_MOD)
     }
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrder.substitutions
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrder.substitutions
@@ -1,0 +1,4 @@
+file Demo.WorkOrderVariable.template {
+{ P=$(P=), R=WOVAR:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable }
+{ P=$(P=), R=WOVAR2:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable2 }
+}

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrderVariable.template
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrderVariable.template
@@ -1,0 +1,55 @@
+# Database connecting to the UaServerCpp example server
+# that is part of all Unified Automation bundles
+
+# WorkOrder part of the Demo server (user defined structures)
+
+# Records connecting to an instance of WorkOrder Variable
+
+# Macros:
+# P         = Record name prefix
+# R         = Record name prefix of the structure
+# SESS      = Session name
+# SUBS      = Subscription name
+# WO_NODEID = Complete node name of the OPC UA variable
+
+# R/W version (bidirectional output records)
+
+record(opcuaItem, "$(P)$(R)item") {
+    field(DTYP, "OPCUA")
+    field(INP,  "@$(SUBS) ns=2;s=$(WO_NODEID)")
+    field(TSE,  "-2")
+}
+
+record(stringout, "$(P)$(R)assetid") {
+    field(DTYP, "OPCUA")
+    field(OUT,  "@$(P)$(R)item element=AssetID")
+    field(TSE,  "-2")
+}
+
+record(stringout, "$(P)$(R)starttime") {
+    field(DTYP, "OPCUA")
+    field(OUT,  "@$(P)$(R)item element=StartTime")
+    field(TSE,  "-2")
+}
+
+
+# R/O version (input records)
+
+record(opcuaItem, "$(P)$(R)itemRBK") {
+    field(DTYP, "OPCUA")
+    field(INP,  "@$(SUBS) ns=2;s=$(WO_NODEID)")
+    field(TSE,  "-2")
+}
+
+record(stringin, "$(P)$(R)assetidRBK") {
+    field(DTYP, "OPCUA")
+    field(INP,  "@$(P)$(R)itemRBK element=AssetID")
+    field(TSE,  "-2")
+}
+
+record(stringin, "$(P)$(R)starttimeRBK") {
+    field(DTYP, "OPCUA")
+    field(INP,  "@$(P)$(R)itemRBK element=StartTime")
+    field(SCAN, "I/O Intr")
+    field(TSE,  "-2")
+}

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Makefile
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Makefile
@@ -24,6 +24,8 @@ DB += Demo.Static.ArraysE7.db
 DB += Demo.Static.Scalar.db
 DB += Demo.Static.ScalarE7.db
 
+DB += Demo.WorkOrder.db
+
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add
 # <anyname>_template = <templatename>

--- a/exampleTop/iocBoot/iocUaDemoServer/st.cmd
+++ b/exampleTop/iocBoot/iocUaDemoServer/st.cmd
@@ -11,17 +11,22 @@ cd "${TOP}"
 dbLoadDatabase "dbd/opcuaIoc.dbd"
 opcuaIoc_registerRecordDeviceDriver pdbbase
 
-## Pretty minimal setup: one session with a 200ms subscription on top
+# Pretty minimal setup: one session with a 200ms subscription on top
 opcuaCreateSession OPC1 opc.tcp://localhost:48010
 opcuaCreateSubscription SUB1 OPC1 200
 
-## Load the databases for the UaServerCpp demo server
+# Switch off security
+opcuaSetOption OPC1 sec-mode None
+
+# Load the databases for the UaServerCpp demo server
 
 dbLoadRecords "db/UaDemoServer-server.db", "P=OPC:,R=,SESS=OPC1,SUBS=SUB1"
 dbLoadRecords "db/Demo.Dynamic.Arrays.db", "P=OPC:,R=DDA:,SESS=OPC1,SUBS=SUB1"
 dbLoadRecords "db/Demo.Dynamic.Scalar.db", "P=OPC:,R=DDS:,SESS=OPC1,SUBS=SUB1"
 dbLoadRecords "db/Demo.Static.Arrays.db", "P=OPC:,R=DSA:,SESS=OPC1,SUBS=SUB1"
 dbLoadRecords "db/Demo.Static.Scalar.db", "P=OPC:,R=DSS:,SESS=OPC1,SUBS=SUB1"
+
+dbLoadRecords "db/Demo.WorkOrder.db", "P=OPC:,SESS=OPC1,SUBS=SUB1"
 
 # int64 and long string records need EPICS 7
 dbLoadRecords "db/Demo.Dynamic.ScalarE7.db", "P=OPC:,R=DDS:,SESS=OPC1,SUBS=SUB1"
@@ -30,6 +35,3 @@ dbLoadRecords "db/Demo.Static.ScalarE7.db", "P=OPC:,R=DSS:,SESS=OPC1,SUBS=SUB1"
 dbLoadRecords "db/Demo.Static.ArraysE7.db", "P=OPC:,R=DSA:,SESS=OPC1,SUBS=SUB1"
 
 iocInit
-
-## Start any sequence programs
-#seq sncopcuaIoc,"user=ralph"


### PR DESCRIPTION
To support a mode where changing any element of a data structure always writes the complete structure to the server, a new field `WOC` (write-on-change) is introduced in the opcuaItemRecord, currently supporting two options:
- `manual` (default): as before, cache the outgoing data and write when the opcuaItemRecord is processed for writing.
- `immediate`: whenever any element of the data structure is modified, immediate processing of the item record in write mode is requested.

If the data structure is "dirty" (has changed elements), switching from `manual` to `immediate` will trigger write processing.

(Closes issue #112.)