### PR TITLE
Allow getting record timestamps from data

### DIFF
--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -88,8 +88,10 @@ DataElementUaSdk::show (const int level, const unsigned int indent) const
         std::cout << "leaf=" << name << " record(" << pconnector->getRecordType() << ")="
                   << pconnector->getRecordName()
                   << " type=" << variantTypeString(incomingData.type())
-                  << " timestamp=" << (pconnector->plinkinfo->useServerTimestamp ? "server" : "source")
-                  << " bini=" << linkOptionBiniString(pconnector->plinkinfo->bini)
+                  << " timestamp=" << linkOptionTimestampString(pconnector->plinkinfo->timestamp);
+        if (pconnector->plinkinfo->timestamp == LinkOptionTimestamp::data)
+            std::cout << "@" << pitem->linkinfo.timestampElement;
+        std::cout << " bini=" << linkOptionBiniString(pconnector->plinkinfo->bini)
                   << " monitor=" << (pconnector->plinkinfo->monitor ? "y" : "n") << "\n";
     } else {
         std::cout << "node=" << name << " children=" << elements.size()
@@ -315,8 +317,10 @@ DataElementUaSdk::dbgReadScalar (const UpdateUaSdk *upd,
 
         std::cout << pconnector->getRecordName() << ": ";
         if (reason == ProcessReason::incomingData || reason == ProcessReason::readComplete) {
-            std::cout << "(" << ( pconnector->plinkinfo->useServerTimestamp ? "server" : "device")
-                      << " time " << time_buf << ") read " << processReasonString(reason) << " ("
+            std::cout << "(" << linkOptionTimestampString(pconnector->plinkinfo->timestamp);
+            if (pconnector->plinkinfo->timestamp == LinkOptionTimestamp::data)
+                std::cout << "(@" << pconnector->plinkinfo->timestampElement << ")";
+            std::cout << " time " << time_buf << ") read " << processReasonString(reason) << " ("
                       << UaStatus(upd->getStatus()).toString().toUtf8() << ") ";
             UaVariant &data = upd->getData();
             if (data.type() == OpcUaType_String)
@@ -455,8 +459,10 @@ DataElementUaSdk::dbgReadArray (const UpdateUaSdk *upd,
 
         std::cout << pconnector->getRecordName() << ": ";
         if (reason == ProcessReason::incomingData || reason == ProcessReason::readComplete) {
-            std::cout << "(" << ( pconnector->plinkinfo->useServerTimestamp ? "server" : "device")
-                      << " time " << time_buf << ") read " << processReasonString(reason) << " ("
+            std::cout << "(" << linkOptionTimestampString(pconnector->plinkinfo->timestamp);
+            if (pconnector->plinkinfo->timestamp == LinkOptionTimestamp::data)
+                std::cout << "@" << pconnector->plinkinfo->timestampElement;
+            std::cout << " time " << time_buf << ") read " << processReasonString(reason) << " ("
                       << UaStatus(upd->getStatus()).toString().toUtf8() << ") ";
             UaVariant &data = upd->getData();
             std::cout << " array of " << variantTypeString(data.type())

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -233,8 +233,11 @@ public:
      *
      * @param value  new value for this data element
      * @param reason  reason for this value update
+     * @param timefrom  name of element to read item timestamp from
      */
-    void setIncomingData(const UaVariant &value, ProcessReason reason);
+    void setIncomingData(const UaVariant &value,
+                         ProcessReason reason,
+                         const std::string *timefrom = nullptr);
 
     /**
      * @brief Push an incoming event into the DataElement.
@@ -679,6 +682,18 @@ private:
         pitem->markAsDirty();
     }
 
+    // Convert the time stamp from a data element
+    epicsTime
+    epicsTimeFromUaVariant(const UaVariant &data) const
+    {
+        UaDateTime dt;
+        UaStatus s = data.toDateTime(dt);
+        if (s.isGood()) {
+            return ItemUaSdk::uaToEpicsTime(dt, 0);
+        }
+        return pitem->tsSource;
+    }
+
     // Get the time stamp from the incoming object
     const epicsTime &getIncomingTimeStamp() const {
         ProcessReason reason = pitem->getReason();
@@ -1088,6 +1103,7 @@ private:
     std::shared_ptr<DataElementUaSdk> parent;               /**< parent */
 
     std::unordered_map<int, std::weak_ptr<DataElementUaSdk>> elementMap;
+    int timesrc;
 
     bool mapped;                             /**< child name to index mapping done */
     UpdateQueue<UpdateUaSdk> incomingQueue;  /**< queue of incoming values */

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -684,12 +684,15 @@ private:
         ProcessReason reason = pitem->getReason();
         if ((reason == ProcessReason::incomingData || reason == ProcessReason::readComplete)
                 && isLeaf())
-            if (pconnector->plinkinfo->useServerTimestamp)
+            switch (pconnector->plinkinfo->timestamp) {
+            case LinkOptionTimestamp::server:
                 return pitem->tsServer;
-            else
+            case LinkOptionTimestamp::source:
                 return pitem->tsSource;
-        else
-            return pitem->tsClient;
+            case LinkOptionTimestamp::data:
+                return pitem->tsData;
+            }
+        return pitem->tsClient;
     }
 
     // Get the read status from the incoming object

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -20,6 +20,7 @@
 
 #include <osiSock.h> // needed before callback.h to get Windows definition of CALLBACK in
 
+#include "devOpcua.h"
 #include "RecordConnector.h"
 #include "opcuaItemRecord.h"
 #include "ItemUaSdk.h"
@@ -104,21 +105,19 @@ ItemUaSdk::show (int level) const
               << " state=" << connectionStatusString(connState)
               << " status=" << UaStatus(lastStatus).toString().toUtf8()
               << " dataDirty=" << (dataTreeDirty ? "y" : "n")
-              << " context=" << linkinfo.subscription
-              << "@" << session->getName()
-              << " sampling=" << revisedSamplingInterval
-              << "(" << linkinfo.samplingInterval << ")"
-              << " qsize=" << revisedQueueSize
-              << "(" << linkinfo.queueSize << ")"
+              << " context=" << linkinfo.subscription << "@" << session->getName()
+              << " sampling=" << revisedSamplingInterval << "(" << linkinfo.samplingInterval << ")"
+              << " qsize=" << revisedQueueSize << "(" << linkinfo.queueSize << ")"
               << " cqsize=" << linkinfo.clientQueueSize
               << " discard=" << (linkinfo.discardOldest ? "old" : "new")
-              << " timestamp=" << (linkinfo.useServerTimestamp ? "server" : "source")
-              << " bini=" << linkOptionBiniString(linkinfo.bini)
+              << " timestamp=" << linkOptionTimestampString(linkinfo.timestamp);
+    if (linkinfo.timestamp == LinkOptionTimestamp::data)
+        std::cout << "@" << linkinfo.timestampElement;
+    std::cout << " bini=" << linkOptionBiniString(linkinfo.bini)
               << " output=" << (linkinfo.isOutput ? "y" : "n")
               << " monitor=" << (linkinfo.monitor ? "y" : "n")
-              << " registered=" << (registered ? nodeid->toString().toUtf8() : "-" )
-              << "(" << (linkinfo.registerNode ? "y" : "n") << ")"
-              << std::endl;
+              << " registered=" << (registered ? nodeid->toString().toUtf8() : "-") << "("
+              << (linkinfo.registerNode ? "y" : "n") << ")" << std::endl;
 
     if (level >= 1) {
         if (auto re = dataTree.root().lock()) {
@@ -231,10 +230,17 @@ ItemUaSdk::getStatus(epicsUInt32 *code, char *text, const epicsUInt32 len, epics
     }
 
     if (ts && recConnector) {
-        if (recConnector->plinkinfo->useServerTimestamp)
+        switch (recConnector->plinkinfo->timestamp) {
+        case LinkOptionTimestamp::server:
             *ts = tsServer;
-        else
+            break;
+        case LinkOptionTimestamp::source:
             *ts = tsSource;
+            break;
+        case LinkOptionTimestamp::data:
+            *ts = tsData;
+            break;
+        }
     }
 }
 

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -175,8 +175,12 @@ ItemUaSdk::setIncomingData(const OpcUa_DataValue &value, ProcessReason reason)
 
     setLastStatus(value.StatusCode);
 
-    if (auto pd = dataTree.root().lock())
-        pd->setIncomingData(value.Value, reason);
+    if (auto pd = dataTree.root().lock()) {
+        const std::string *timefrom = nullptr;
+        if (linkinfo.timestamp == LinkOptionTimestamp::data && linkinfo.timestampElement.length())
+            timefrom = &linkinfo.timestampElement;
+        pd->setIncomingData(value.Value, reason, timefrom);
+    }
 
     if (linkinfo.isItemRecord) {
         if (state() == ConnectionStatus::initialRead

--- a/devOpcuaSup/UaSdk/ItemUaSdk.h
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.h
@@ -234,7 +234,8 @@ private:
     ConnectionStatus connState;            /**< Connection state of the item */
     epicsTime tsClient;                    /**< client (local) time stamp */
     epicsTime tsServer;                    /**< server time stamp */
-    epicsTime tsSource;                    /**< device time stamp */
+    epicsTime tsSource;                    /**< source time stamp */
+    epicsTime tsData;                      /**< data time stamp */
 };
 
 } // namespace DevOpcua

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -46,6 +46,22 @@ linkOptionBiniString (const LinkOptionBini choice)
 }
 
 /**
+ * @brief Enum for the choices of the timestamp link option.
+ */
+enum LinkOptionTimestamp { server, source, data };
+
+inline const char *
+linkOptionTimestampString (const LinkOptionTimestamp choice)
+{
+    switch(choice) {
+    case server: return "server";
+    case source: return "source";
+    case data:   return "data";
+    }
+    return "Illegal Value";
+}
+
+/**
  * @brief Report that PINI is set for a record and clear it.
  *
  * @param prec  pointer to record
@@ -88,7 +104,8 @@ typedef struct linkInfo {
 
     std::string element;
     std::list<std::string> elementPath;
-    bool useServerTimestamp = true;
+    LinkOptionTimestamp timestamp = LinkOptionTimestamp::server;
+    std::string timestampElement;
     LinkOptionBini bini = LinkOptionBini::read;
 
     bool isOutput;


### PR DESCRIPTION
This feature allows to set a structure element (first level) as source for element record timestamps.

(Closing #75.)