### PR TITLE
Update iocShell interface

### DIFF
--- a/devOpcuaSup/Session.h
+++ b/devOpcuaSup/Session.h
@@ -167,9 +167,7 @@ public:
      * @return  pointer to the new session, nullptr if not created
      */
     static Session *createSession(const std::string &name,
-                                  const std::string &url,
-                                  const int debuglevel,
-                                  const bool autoconnect);
+                                  const std::string &url);
 
     /**
      * @brief Find a session by name (implementation specific).
@@ -229,11 +227,11 @@ public:
     int debug;  /**< debug verbosity level */
 
 protected:
-    Session(const std::string &name, const int debug, const bool autoConnect)
-        : debug(debug)
+    Session(const std::string &name)
+        : debug(0)
         , name(name)
         , autoConnector(*this, opcua_ConnectTimeout, queue)
-        , autoConnect(autoConnect)
+        , autoConnect(true)
     {
         char host[HOST_NAME_MAX] = {0};
         int status = gethostname(host, sizeof(host));

--- a/devOpcuaSup/Session.h
+++ b/devOpcuaSup/Session.h
@@ -188,11 +188,6 @@ public:
     static std::set<Session *> glob(const std::string &pattern);
 
     /**
-     * @brief Print help text for available options.
-     */
-    static void showOptionHelp();
-
-    /**
      * @brief Set client certificate (public key, private key) file paths.
      *
      * @param pubPath  full path to certificate (public key)
@@ -223,6 +218,8 @@ public:
      * @param location  location for saving rejected certs (empty = use default)
      */
     static void saveRejected(const std::string &location = "");
+
+    static const char optionUsage[]; /**< option info for the specific implementation */
 
     int debug;  /**< debug verbosity level */
 

--- a/devOpcuaSup/Subscription.h
+++ b/devOpcuaSup/Subscription.h
@@ -41,16 +41,12 @@ public:
      * @param name  subscription name
      * @param session  session that the subscription should be linked to
      * @param publishingInterval  initial publishing interval
-     * @param priority  priority (default 0=lowest)
-     * @param debug  initial debug verbosity (default 0=no debug)
      *
      * @return  pointer to the new subscription, nullptr if not created
      */
     static Subscription *createSubscription(const std::string &name,
                                             const std::string &session,
-                                            const double publishingInterval,
-                                            const epicsUInt8 priority = 0,
-                                            const int debug = 0);
+                                            const double publishingInterval);
     /**
      * @brief Print configuration and status on stdout.
      *
@@ -117,9 +113,9 @@ protected:
      *
      * @param debug  initial debug level
      */
-    Subscription(const std::string &name, const int debug)
+    Subscription(const std::string &name)
         : name(name)
-        , debug(debug) {}
+        , debug(0) {}
 };
 
 } // namespace DevOpcua

--- a/devOpcuaSup/Subscription.h
+++ b/devOpcuaSup/Subscription.h
@@ -62,6 +62,14 @@ public:
     virtual void show(int level) const = 0;
 
     /**
+     * @brief Set an option for the subscription.
+     *
+     * @param name   option name
+     * @param value  value
+     */
+    virtual void setOption(const std::string &name, const std::string &value) = 0;
+
+    /**
      * @brief Print configuration and status of all subscriptions on stdout.
      *
      * The verbosity level controls the amount of information:

--- a/devOpcuaSup/Subscription.h
+++ b/devOpcuaSup/Subscription.h
@@ -106,6 +106,8 @@ public:
      */
     static std::set<Subscription *> glob(const std::string &pattern);
 
+    static const char optionUsage[]; /**< option info for the specific implementation */
+
     const std::string name; /**< subscription name */
     int debug;              /**< debug verbosity level */
 

--- a/devOpcuaSup/UaSdk/Session.cpp
+++ b/devOpcuaSup/UaSdk/Session.cpp
@@ -160,26 +160,25 @@ Session::showClientSecurity()
 }
 #endif
 
-void
-Session::showOptionHelp ()
-{
-    std::cout << "Options:\n"
-              << "clientcert         path to client certificate [none]\n"
-              << "clientkey          path to client private key [none]\n"
-              << "nodes-max          max. nodes per service call [0 = no limit]\n"
-              << "read-nodes-max     max. nodes per read service call [0 = no limit]\n"
-              << "read-timeout-min   min. timeout (holdoff) after read service call [ms]\n"
-              << "read-timeout-max   timeout (holdoff) after read service call w/ max elements [ms]\n"
-              << "write-nodes-max    max. nodes per write service call [0 = no limit]\n"
-              << "write-timeout-min  min. timeout (holdoff) after write service call [ms]\n"
-              << "write-timeout-max  timeout (holdoff) after write service call w/ max elements [ms]"
-              << "sec-mode           requested security mode\n"
-              << "sec-policy         requested security policy\n"
-              << "sec-level-min      requested minimal security level\n"
-              << "ident-file         file to read identity credentials from\n"
-              << "batch-nodes        max. nodes per service call [0 = no limit]"
-              << std::endl;
-}
+const char Session::optionUsage[]
+    = "Sets options for existing OPC UA sessions or subscriptions.\n\n"
+      "pattern    pattern for session or subscription names (* and ? supported)\n"
+      "[options]  colon separated list of options in 'key=value' format\n\n"
+      "Valid session options are:\n"
+      "debug              debug level [default 0 = no debug]\n"
+      "nodes-max          max. nodes per service call [0 = no limit]\n"
+      "read-nodes-max     max. nodes per read service call [0 = no limit]\n"
+      "read-timeout-min   min. timeout (holdoff) after read service call [ms]\n"
+      "read-timeout-max   timeout (holdoff) after read service call w/ max elements [ms]\n"
+      "write-nodes-max    max. nodes per write service call [0 = no limit]\n"
+      "write-timeout-min  min. timeout (holdoff) after write service call [ms]\n"
+      "write-timeout-max  timeout (holdoff) after write service call w/ max elements [ms]\n"
+      "clientcert         path to client certificate [none]\n"
+      "clientkey          path to client private key [none]\n"
+      "sec-mode           requested security mode\n"
+      "sec-policy         requested security policy\n"
+      "ident-file         file to read identity credentials from\n\n"
+      "";
 
 void
 Session::setupPKI(const std::string &&certTrustList,

--- a/devOpcuaSup/UaSdk/Session.cpp
+++ b/devOpcuaSup/UaSdk/Session.cpp
@@ -71,14 +71,12 @@ isWritable(const std::string &dir)
 
 Session *
 Session::createSession(const std::string &name,
-                       const std::string &url,
-                       const int debuglevel,
-                       const bool autoconnect)
+                       const std::string &url)
 {
     epicsThreadOnce(&opcuaUaSdk_once, &opcuaUaSdk_init, nullptr);
     if (RegistryKeyNamespace::global.contains(name))
         return nullptr;
-    return new SessionUaSdk(name, url, autoconnect, debuglevel);
+    return new SessionUaSdk(name, url);
 }
 
 Session *

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -913,7 +913,9 @@ SessionUaSdk::show (const int level) const
               << " url="         << serverURL.toUtf8()
               << " status="      << serverStatusString(serverConnectionStatus)
               << " sec-mode="    << securityModeString(securityInfo.messageSecurityMode)
+              << "(" << reqSecurityModeString(reqSecurityMode) << ")"
               << " sec-policy="  << securityPolicyString(securityInfo.sSecurityPolicy.toUtf8())
+              << "(" << securityPolicyString(reqSecurityPolicyURI.toUtf8()) << ")"
               << " debug="       << debug
               << " batch=";
     if (isConnected())

--- a/devOpcuaSup/UaSdk/SessionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.cpp
@@ -140,10 +140,8 @@ SessionUaSdk::connectResultString (const ConnectResult result)
 }
 
 SessionUaSdk::SessionUaSdk(const std::string &name,
-                           const std::string &serverUrl,
-                           bool autoConnect,
-                           int debug)
-    : Session(name, debug, autoConnect)
+                           const std::string &serverUrl)
+    : Session(name)
     , serverURL(serverUrl.c_str())
     , registeredItemsNo(0)
     , puasession(new UaSession())
@@ -194,6 +192,10 @@ SessionUaSdk::setOption (const std::string &name, const std::string &value)
     bool updateReadBatcher = false;
     bool updateWriteBatcher = false;
 
+    if (debug || name == "debug")
+        std::cerr << "Session " << this->name << ": setting option " << name << " to " << value
+                  << std::endl;
+
     if (name == "sec-mode") {
         if (value == "best") {
             reqSecurityMode = RequestedSecurityMode::Best;
@@ -222,6 +224,9 @@ SessionUaSdk::setOption (const std::string &name, const std::string &value)
         }
     } else if (name == "sec-id") {
         securityIdentityFile = value;
+    } else if (name == "debug") {
+        unsigned long ul = std::strtoul(value.c_str(), nullptr, 0);
+        debug = ul;
     } else if (name == "batch-nodes") {
         errlogPrintf("DEPRECATED: option 'batch-nodes'; use 'nodes-max' instead\n");
         unsigned long ul = std::strtoul(value.c_str(), nullptr, 0);
@@ -261,7 +266,7 @@ SessionUaSdk::setOption (const std::string &name, const std::string &value)
         if (value.length() > 0)
             autoConnect = getYesNo(value[0]);
     } else {
-        errlogPrintf("unknown option '%s' ignored\n", name.c_str());
+        errlogPrintf("unknown option '%s' - ignored\n", name.c_str());
     }
 
     unsigned int max = 0;

--- a/devOpcuaSup/UaSdk/SessionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.h
@@ -75,15 +75,8 @@ public:
      *
      * @param name               session name (used in EPICS record configuration)
      * @param serverUrl          OPC UA server URL
-     * @param autoConnect        if true (default), client will automatically connect
-     *                           both initially and after connection loss
-     * @param debug              initial debug verbosity level
-     * @param batchNodes         max. number of node to use in any single service call
-     * @param clientCertificate  path to client-side certificate
-     * @param clientPrivateKey   path to client-side private key
      */
-    SessionUaSdk(const std::string &name, const std::string &serverUrl,
-                 bool autoConnect = true, int debug = 0);
+    SessionUaSdk(const std::string &name, const std::string &serverUrl);
     ~SessionUaSdk() override;
 
     /**

--- a/devOpcuaSup/UaSdk/Subscription.cpp
+++ b/devOpcuaSup/UaSdk/Subscription.cpp
@@ -56,4 +56,9 @@ Subscription::showAll (const int level)
     SubscriptionUaSdk::showAll(level);
 }
 
+const char Subscription::optionUsage[]
+    = "Valid subscription options are:\n"
+      "debug              debug level [default 0 = no debug]\n"
+      "";
+
 } // namespace DevOpcua

--- a/devOpcuaSup/UaSdk/Subscription.cpp
+++ b/devOpcuaSup/UaSdk/Subscription.cpp
@@ -28,14 +28,12 @@ Subscription::~Subscription() {}
 Subscription *
 Subscription::createSubscription(const std::string &name,
                                  const std::string &session,
-                                 const double publishingInterval,
-                                 const epicsUInt8 priority,
-                                 const int debug)
+                                 const double publishingInterval)
 {
     SessionUaSdk *s = SessionUaSdk::find(session);
     if (RegistryKeyNamespace::global.contains(name) || !s)
         return nullptr;
-    return new SubscriptionUaSdk(name, s, publishingInterval, priority, debug);
+    return new SubscriptionUaSdk(name, s, publishingInterval);
 }
 
 Subscription *
@@ -59,6 +57,7 @@ Subscription::showAll (const int level)
 const char Subscription::optionUsage[]
     = "Valid subscription options are:\n"
       "debug              debug level [default 0 = no debug]\n"
+      "priority           priority level [default 0(lowest) .. 255]\n"
       "";
 
 } // namespace DevOpcua

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
@@ -54,6 +54,20 @@ SubscriptionUaSdk::SubscriptionUaSdk (const std::string &name, SessionUaSdk *ses
     psessionuasdk->subscriptions[name] = this;
 }
 
+void SubscriptionUaSdk::setOption(const std::string &name, const std::string &value)
+{
+    if (debug || name == "debug")
+        std::cerr << "Subscription " << this->name << ": setting option " << name << " to " << value
+                  << std::endl;
+
+    if (name == "debug") {
+        unsigned long ul = std::strtoul(value.c_str(), nullptr, 0);
+        debug = ul;
+    } else {
+        errlogPrintf("unknown option '%s' - ignored\n", name.c_str());
+    }
+}
+
 void
 SubscriptionUaSdk::show (int level) const
 {

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
@@ -36,9 +36,8 @@ using namespace UaClientSdk;
 Registry<SubscriptionUaSdk> SubscriptionUaSdk::subscriptions;
 
 SubscriptionUaSdk::SubscriptionUaSdk (const std::string &name, SessionUaSdk *session,
-                                      const double publishingInterval, const epicsUInt8 priority,
-                                      const int debug)
-    : Subscription(name, debug)
+                                      const double publishingInterval)
+    : Subscription(name)
     , puasubscription(nullptr)
     , psessionuasdk(session)
     //TODO: add runtime support for subscription enable/disable
@@ -48,7 +47,6 @@ SubscriptionUaSdk::SubscriptionUaSdk (const std::string &name, SessionUaSdk *ses
     double deftimeout = subscriptionSettings.publishingInterval * subscriptionSettings.lifetimeCount;
     subscriptionSettings.publishingInterval = requestedSettings.publishingInterval = publishingInterval;
     subscriptionSettings.lifetimeCount = requestedSettings.lifetimeCount = static_cast<OpcUa_UInt32>(deftimeout / publishingInterval);
-    subscriptionSettings.priority = requestedSettings.priority = priority;
 
     subscriptions.insert({name, this});
     psessionuasdk->subscriptions[name] = this;
@@ -63,6 +61,12 @@ void SubscriptionUaSdk::setOption(const std::string &name, const std::string &va
     if (name == "debug") {
         unsigned long ul = std::strtoul(value.c_str(), nullptr, 0);
         debug = ul;
+    } else if (name == "priority") {
+        unsigned long ul = std::strtoul(value.c_str(), nullptr, 0);
+        if (ul > 255ul)
+            errlogPrintf("option '%s' value out of range - ignored\n", name.c_str());
+        else
+            subscriptionSettings.priority = requestedSettings.priority = ul;
     } else {
         errlogPrintf("unknown option '%s' - ignored\n", name.c_str());
     }

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
@@ -58,6 +58,11 @@ public:
                       const int debug = 0);
 
     /**
+     * @brief Set an option for the subscription. See DevOpcua::Subscription::setOption
+     */
+    virtual void setOption(const std::string &name, const std::string &value) override;
+
+    /**
      * @brief Print configuration and status. See DevOpcua::Subscription::show
      */
     virtual void show(int level) const override;

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
@@ -50,12 +50,9 @@ public:
      * @param name  subscription name
      * @param session  session that the subscription should be linked to
      * @param publishingInterval  initial publishing interval
-     * @param priority  priority (default 0=lowest)
-     * @param debug  debug verbosity (default 0=no debug)
      */
     SubscriptionUaSdk(const std::string &name, SessionUaSdk *session,
-                      const double publishingInterval, const epicsUInt8 priority = 0,
-                      const int debug = 0);
+                      const double publishingInterval);
 
     /**
      * @brief Set an option for the subscription. See DevOpcua::Subscription::setOption

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -169,6 +169,8 @@ static const iocshArg opcuaSetOptionArg0 = {"session name", iocshArgString};
 static const iocshArg opcuaSetOptionArg1 = {"option name", iocshArgString};
 static const iocshArg opcuaSetOptionArg2 = {"option value", iocshArgString};
 
+static const std::string opcuaOptionsUsage = std::string(Session::optionUsage) + Subscription::optionUsage;
+
 static const iocshArg *const opcuaSetOptionArg[3] = {&opcuaSetOptionArg0, &opcuaSetOptionArg1,
                                                      &opcuaSetOptionArg2};
 
@@ -217,7 +219,7 @@ void opcuaSetOptionCallFunc (const iocshArgBuf *args)
 
         if (ok) {
             if (help)
-                Session::showOptionHelp();
+                std::cout << opcuaOptionsUsage.c_str() << std::endl;
             else
                 s->setOption(args[1].sval, args[2].sval);
         }

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -922,9 +922,7 @@ static
         }
 
         if (ok) {
-            Subscription *s = Subscription::createSubscription(args[0].sval,
-                                                               args[1].sval,
-                                                               publishingInterval);
+            s = Subscription::createSubscription(args[0].sval, args[1].sval, publishingInterval);
             if (s && debuglevel) {
                 errlogPrintf("opcuaCreateSubscription: successfully configured subscription '%s'\n",
                              args[0].sval);
@@ -938,7 +936,7 @@ static
             errlogPrintf("out-of-range argument #4 (priority) '%d' - ignored\n",
                          args[3].ival);
         } else {
-            if (ok && args[3].ival)
+            if (s)
                 s->setOption("priority", std::to_string(args[3].ival));
         }
 

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -179,8 +179,8 @@ opcuaSessionCallFunc(const iocshArgBuf *args)
     }
 }
 
-static const iocshArg opcuaSubscriptionArg0 = {"subscription name", iocshArgString};
-static const iocshArg opcuaSubscriptionArg1 = {"session name", iocshArgString};
+static const iocshArg opcuaSubscriptionArg0 = {"name", iocshArgString};
+static const iocshArg opcuaSubscriptionArg1 = {"session", iocshArgString};
 static const iocshArg opcuaSubscriptionArg2 = {"publishing interval [ms]", iocshArgDouble};
 static const iocshArg opcuaSubscriptionArg3 = {"[options]", iocshArgString};
 
@@ -189,7 +189,23 @@ static const iocshArg *const opcuaSubscriptionArg[4] = {&opcuaSubscriptionArg0,
                                                         &opcuaSubscriptionArg2,
                                                         &opcuaSubscriptionArg3};
 
-static const iocshFuncDef opcuaSubscriptionFuncDef = {"opcuaSubscription", 4, opcuaSubscriptionArg};
+const char opcuaSubscriptionUsage[]
+    = "Configures a new OPC UA subscription, assigning it a name and creating it under an existing "
+      "session.\nMust be called before iocInit.\n\n"
+      "name                 subscription name (no spaces)\n"
+      "session              name of the existing OPC UA session for the new subscription\n"
+      "publishing interval  publishing interval for the new subscription (in ms)\n"
+      "[options]            colon separated list of options in 'key=value' format\n"
+      "                     (see 'help opcuaOptions' for a list of valid options)\n";
+
+static const iocshFuncDef opcuaSubscriptionFuncDef = {"opcuaSubscription",
+                                                      4,
+                                                      opcuaSubscriptionArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                      ,
+                                                      opcuaSubscriptionUsage
+#endif
+};
 
 static
     void opcuaSubscriptionCallFunc (const iocshArgBuf *args)
@@ -343,7 +359,19 @@ static const iocshArg opcuaShowArg1 = {"verbosity", iocshArgInt};
 
 static const iocshArg *const opcuaShowArg[2] = {&opcuaShowArg0, &opcuaShowArg1};
 
-static const iocshFuncDef opcuaShowFuncDef = {"opcuaShow", 2, opcuaShowArg};
+const char opcuaShowUsage[]
+    = "Prints information about sessions, subscriptions, items and their related data elements.\n\n"
+      "pattern    glob pattern (supports * and ?) for session, subscription, record names\n"
+      "verbosity  amount of printed information (default 0 = sparse)\n";
+
+static const iocshFuncDef opcuaShowFuncDef = {"opcuaShow",
+                                              2,
+                                              opcuaShowArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                              ,
+                                              opcuaShowUsage
+#endif
+};
 
 static void
 opcuaShowCallFunc(const iocshArgBuf *args)
@@ -379,11 +407,23 @@ opcuaShowCallFunc(const iocshArgBuf *args)
     }
 }
 
-static const iocshArg opcuaConnectArg0 = {"session name", iocshArgString};
+static const iocshArg opcuaConnectArg0 = {"session", iocshArgString};
 
 static const iocshArg *const opcuaConnectArg[1] = {&opcuaConnectArg0};
 
-static const iocshFuncDef opcuaConnectFuncDef = {"opcuaConnect", 1, opcuaConnectArg};
+const char opcuaConnectUsage[]
+    = "Attempts to connect sessions to the configured OPC UA server.\n"
+      "For sessions with configured autoconnect option, the autoconnector is started.\n\n"
+      "session  glob pattern (supports * and ?) for session names\n";
+
+static const iocshFuncDef opcuaConnectFuncDef = {"opcuaConnect",
+                                                 1,
+                                                 opcuaConnectArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                 ,
+                                                 opcuaConnectUsage
+#endif
+};
 
 static
     void opcuaConnectCallFunc (const iocshArgBuf *args)
@@ -391,7 +431,7 @@ static
     bool ok = true;
 
     if (args[0].sval == nullptr) {
-        errlogPrintf("ERROR : missing argument #1 (session name)\n");
+        errlogPrintf("ERROR : missing argument #1 (session name pattern)\n");
         ok = false;
     }
 
@@ -410,7 +450,19 @@ static const iocshArg opcuaDisconnectArg0 = {"session name", iocshArgString};
 
 static const iocshArg *const opcuaDisconnectArg[1] = {&opcuaDisconnectArg0};
 
-static const iocshFuncDef opcuaDisconnectFuncDef = {"opcuaDisconnect", 1, opcuaDisconnectArg};
+const char opcuaDisconnectUsage[]
+    = "Gracefully disconnects sessions from the configured server.\n"
+      "For sessions with configured autoconnect option, the autoconnector is stopped.\n\n"
+      "session  glob pattern (supports * and ?) for session names\n";
+
+static const iocshFuncDef opcuaDisconnectFuncDef = {"opcuaDisconnect",
+                                                    1,
+                                                    opcuaDisconnectArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                    ,
+                                                    opcuaDisconnectUsage
+#endif
+};
 
 static
     void opcuaDisconnectCallFunc (const iocshArgBuf *args)
@@ -433,14 +485,30 @@ static
     }
 }
 
-static const iocshArg opcuaMapNamespaceArg0 = {"session name", iocshArgString};
+static const iocshArg opcuaMapNamespaceArg0 = {"session", iocshArgString};
 static const iocshArg opcuaMapNamespaceArg1 = {"namespace index", iocshArgInt};
 static const iocshArg opcuaMapNamespaceArg2 = {"namespace URI", iocshArgString};
 
 static const iocshArg *const opcuaMapNamespaceArg[3] = {&opcuaMapNamespaceArg0, &opcuaMapNamespaceArg1,
                                                         &opcuaMapNamespaceArg2};
 
-static const iocshFuncDef opcuaMapNamespaceFuncDef = {"opcuaMapNamespace", 3, opcuaMapNamespaceArg};
+const char opcuaMapNamespaceUsage[]
+    = "Adds a namespace mapping to the mapping table of the specified session.\n"
+      "The specified numerical namespace index (used in the loaded databases) will be mapped to "
+      "the\nspecified namespace URI (on the server).\nThis allows to automatically adapt to servers "
+      "that use volatile namespace indices.\n\n"
+      "session          existing session name\n"
+      "namespace index  numerical namespace as used in the database files\n"
+      "namespace URI    full URI identification of that namespace\n";
+
+static const iocshFuncDef opcuaMapNamespaceFuncDef = {"opcuaMapNamespace",
+                                                      3,
+                                                      opcuaMapNamespaceArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                      ,
+                                                      opcuaMapNamespaceUsage
+#endif
+};
 
 static
 void opcuaMapNamespaceCallFunc (const iocshArgBuf *args)
@@ -484,7 +552,18 @@ static const iocshArg opcuaShowSecurityArg0 = {"session name [\"\"=client]", ioc
 
 static const iocshArg *const opcuaShowSecurityArg[1] = {&opcuaShowSecurityArg0};
 
-static const iocshFuncDef opcuaShowSecurityFuncDef = {"opcuaShowSecurity", 1, opcuaShowSecurityArg};
+const char opcuaShowSecurityUsage[]
+    = "Prints information about the security setup of a sepcific session or the IOC client.\n\n"
+      "session name  name of the session to report on (empty string for client report)\n";
+
+static const iocshFuncDef opcuaShowSecurityFuncDef = {"opcuaShowSecurity",
+                                                      1,
+                                                      opcuaShowSecurityArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                      ,
+                                                      opcuaShowSecurityUsage
+#endif
+};
 
 static
 void opcuaShowSecurityCallFunc (const iocshArgBuf *args)
@@ -508,7 +587,17 @@ static const iocshArg opcuaClientCertificateArg1 = {"private key file", iocshArg
 
 static const iocshArg *const opcuaClientCertificateArg[2] = {&opcuaClientCertificateArg0, &opcuaClientCertificateArg1};
 
-static const iocshFuncDef opcuaClientCertificateFuncDef = {"opcuaClientCertificate", 2, opcuaClientCertificateArg};
+const char opcuaClientCertificateUsage[]
+    = "Sets up the OPC UA client certificates to use for the IOC client.\n\n"
+      "certificate file  path to the file containing the certificate (public key)\n"
+      "private key file  path to the file containing the private key\n";
+
+static const iocshFuncDef opcuaClientCertificateFuncDef = {"opcuaClientCertificate", 2, opcuaClientCertificateArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                           ,
+                                                           opcuaClientCertificateUsage
+#endif
+};
 
 static
     void opcuaClientCertificateCallFunc (const iocshArgBuf *args)
@@ -542,7 +631,26 @@ static const iocshArg opcuaSetupPKIArg3 = {"issuer revocation lists location", i
 static const iocshArg *const opcuaSetupPKIArg[4] = {&opcuaSetupPKIArg0, &opcuaSetupPKIArg1,
                                                     &opcuaSetupPKIArg2, &opcuaSetupPKIArg3};
 
-static const iocshFuncDef opcuaSetupPKIFuncDef = {"opcuaSetupPKI", 4, opcuaSetupPKIArg};
+const char opcuaSetupPKIUsage[]
+    = "Sets up the PKI file store of the IOC client, where certificates and revocation lists are "
+      "stored.\n"
+      "The first form (single parameter) expects a standard directory structure under the "
+      "specified location.\n"
+      "The second form (four parameters) explicitly defines the specific locations.\n\n"
+      "PKI / server certs location       path to the PKI structure / to the location of "
+      "trusted server certs\n"
+      "server revocation lists location  path to the location of server revocation lists\n"
+      "issuer certs location             path to the location of issuer certificates\n"
+      "issuer revocation lists location  path to the location of issuer revocation lists\n";
+
+static const iocshFuncDef opcuaSetupPKIFuncDef = {"opcuaSetupPKI",
+                                                  4,
+                                                  opcuaSetupPKIArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                  ,
+                                                  opcuaSetupPKIUsage
+#endif
+};
 
 static
     void opcuaSetupPKICallFunc (const iocshArgBuf *args)
@@ -582,7 +690,18 @@ static const iocshArg opcuaSaveRejectedArg0 = {"location for saving rejected cer
 
 static const iocshArg *const opcuaSaveRejectedArg[1] = {&opcuaSaveRejectedArg0};
 
-static const iocshFuncDef opcuaSaveRejectedFuncDef = {"opcuaSaveRejected", 1, opcuaSaveRejectedArg};
+const char opcuaSaveRejectedUsage[]
+    = "Sets the location where the client will save rejected certificates.\n\n"
+      "rejected certs location  where to save rejected certificates\n";
+
+static const iocshFuncDef opcuaSaveRejectedFuncDef = {"opcuaSaveRejected",
+                                                      1,
+                                                      opcuaSaveRejectedArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                      ,
+                                                      opcuaSaveRejectedUsage
+#endif
+};
 
 static
     void opcuaSaveRejectedCallFunc (const iocshArgBuf *args)

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -437,9 +437,10 @@ static
 
     if (ok) {
         try {
-            Session *s = Session::find(args[0].sval);
-            if (s)
-                s->connect(true);
+            std::set<Session *> sessions = Session::glob(args[0].sval);
+            if (sessions.size())
+                for (auto &s : sessions)
+                    s->connect(true);
         } catch (std::exception &e) {
             std::cerr << "ERROR : " << e.what() << std::endl;
         }
@@ -476,9 +477,10 @@ static
 
     if (ok) {
         try {
-            Session *s = Session::find(args[0].sval);
-            if (s)
-                s->disconnect();
+            std::set<Session *> sessions = Session::glob(args[0].sval);
+            if (sessions.size())
+                for (auto &s : sessions)
+                    s->disconnect();
         } catch (std::exception &e) {
             std::cerr << "ERROR : " << e.what() << std::endl;
         }

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -148,9 +148,14 @@ void opcuaCreateSessionCallFunc (const iocshArgBuf *args)
         }
 
         if (ok) {
-            Session::createSession(args[0].sval, args[1].sval, debuglevel, autoconnect);
-            if (debuglevel)
-                errlogPrintf("opcuaCreateSession: successfully created session '%s'\n", args[0].sval);
+            Session *s = Session::createSession(args[0].sval, args[1].sval);
+            if (debuglevel) {
+                s->setOption("debug", std::to_string(debuglevel));
+                errlogPrintf("opcuaCreateSession: successfully created session '%s'\n",
+                             args[0].sval);
+            }
+            if (!autoconnect)
+                s->setOption("autoconnect", "n");
         } else {
             errlogPrintf("ERROR - no session created\n");
         }


### PR DESCRIPTION
Revamp of the iocShell interface, with simplified, shorter, more powerful commands.
Includes a new format for setting options: `key=value[:key=value ...]` that allows to set any number of options in one call.


(closes #80)
