### PR TITLE
Fix epics type string bug

### DIFF
--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -542,7 +542,7 @@ DataElementUaSdk::readArray (char *value, const epicsUInt32 len,
 
     ProcessReason nReason;
     std::shared_ptr<UpdateUaSdk> upd = incomingQueue.popUpdate(&nReason);
-    dbgReadArray(upd.get(), num, epicsTypeString(*value));
+    dbgReadArray(upd.get(), num, epicsTypeString(value));
 
     switch (upd->getType()) {
     case ProcessReason::readFailure:
@@ -571,7 +571,7 @@ DataElementUaSdk::readArray (char *value, const epicsUInt32 len,
                     ret = 1;
                 } else if (data.type() != expectedType) {
                     errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                 prec->name, variantTypeString(data.type()), epicsTypeString(*value));
+                                 prec->name, variantTypeString(data.type()), epicsTypeString(value));
                     (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                     ret = 1;
                 } else {
@@ -632,7 +632,7 @@ DataElementUaSdk::readArray<epicsUInt8, UaByteArray> (epicsUInt8 *value, const e
 
     ProcessReason nReason;
     std::shared_ptr<UpdateUaSdk> upd = incomingQueue.popUpdate(&nReason);
-    dbgReadArray(upd.get(), num, epicsTypeString(*value));
+    dbgReadArray(upd.get(), num, epicsTypeString(value));
 
     switch (upd->getType()) {
     case ProcessReason::readFailure:
@@ -661,7 +661,7 @@ DataElementUaSdk::readArray<epicsUInt8, UaByteArray> (epicsUInt8 *value, const e
                     ret = 1;
                 } else if (data.type() != expectedType) {
                     errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                 prec->name, variantTypeString(data.type()), epicsTypeString(*value));
+                                 prec->name, variantTypeString(data.type()), epicsTypeString(value));
                     (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                     ret = 1;
                 } else {
@@ -1040,7 +1040,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
                      prec->name,
                      variantTypeString(incomingData.type()),
                      variantTypeString(targetType),
-                     epicsTypeString(**value));
+                     epicsTypeString(*value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1067,7 +1067,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
             markAsDirty();
         }
 
-        dbgWriteArray(num, epicsTypeString(**value));
+        dbgWriteArray(num, epicsTypeString(*value));
     }
     return ret;
 }
@@ -1092,7 +1092,7 @@ DataElementUaSdk::writeArray<epicsUInt8, UaByteArray, OpcUa_Byte> (const epicsUI
                      prec->name,
                      variantTypeString(incomingData.type()),
                      variantTypeString(targetType),
-                     epicsTypeString(*value));
+                     epicsTypeString(value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1103,7 +1103,7 @@ DataElementUaSdk::writeArray<epicsUInt8, UaByteArray, OpcUa_Byte> (const epicsUI
             markAsDirty();
         }
 
-        dbgWriteArray(num, epicsTypeString(*value));
+        dbgWriteArray(num, epicsTypeString(value));
     }
     return ret;
 }

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -35,17 +35,17 @@ class ItemUaSdk;
 
 typedef Update<UaVariant, OpcUa_StatusCode> UpdateUaSdk;
 
-inline const char *epicsTypeString (const epicsInt8 &) { return "epicsInt8"; }
-inline const char *epicsTypeString (const epicsUInt8 &) { return "epicsUInt8"; }
-inline const char *epicsTypeString (const epicsInt16 &) { return "epicsInt16"; }
-inline const char *epicsTypeString (const epicsUInt16 &) { return "epicsUInt16"; }
-inline const char *epicsTypeString (const epicsInt32 &) { return "epicsInt32"; }
-inline const char *epicsTypeString (const epicsUInt32 &) { return "epicsUInt32"; }
-inline const char *epicsTypeString (const epicsInt64 &) { return "epicsInt64"; }
-inline const char *epicsTypeString (const epicsUInt64 &) { return "epicsUInt64"; }
-inline const char *epicsTypeString (const epicsFloat32 &) { return "epicsFloat32"; }
-inline const char *epicsTypeString (const epicsFloat64 &) { return "epicsFloat64"; }
-inline const char *epicsTypeString (const char* &) { return "epicsString"; }
+inline const char *epicsTypeString (const epicsInt8 *) { return "epicsInt8"; }
+inline const char *epicsTypeString (const epicsUInt8 *) { return "epicsUInt8"; }
+inline const char *epicsTypeString (const epicsInt16 *) { return "epicsInt16"; }
+inline const char *epicsTypeString (const epicsUInt16 *) { return "epicsUInt16"; }
+inline const char *epicsTypeString (const epicsInt32 *) { return "epicsInt32"; }
+inline const char *epicsTypeString (const epicsUInt32 *) { return "epicsUInt32"; }
+inline const char *epicsTypeString (const epicsInt64 *) { return "epicsInt64"; }
+inline const char *epicsTypeString (const epicsUInt64 *) { return "epicsUInt64"; }
+inline const char *epicsTypeString (const epicsFloat32 *) { return "epicsFloat32"; }
+inline const char *epicsTypeString (const epicsFloat64 *) { return "epicsFloat64"; }
+inline const char *epicsTypeString (const char *) { return "epicsString"; }
 
 inline const char *
 variantTypeString (const OpcUa_BuiltInType type)
@@ -766,7 +766,7 @@ private:
 
         ProcessReason nReason;
         std::shared_ptr<UpdateUaSdk> upd = incomingQueue.popUpdate(&nReason);
-        dbgReadScalar(upd.get(), epicsTypeString(*value));
+        dbgReadScalar(upd.get(), epicsTypeString(value));
 
         switch (upd->getType()) {
         case ProcessReason::readFailure:
@@ -844,7 +844,7 @@ private:
 
         ProcessReason nReason;
         std::shared_ptr<UpdateUaSdk> upd = incomingQueue.popUpdate(&nReason);
-        dbgReadArray(upd.get(), num, epicsTypeString(*value));
+        dbgReadArray(upd.get(), num, epicsTypeString(value));
 
         switch (upd->getType()) {
         case ProcessReason::readFailure:
@@ -873,7 +873,7 @@ private:
                         ret = 1;
                     } else if (data.type() != expectedType) {
                         errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                     prec->name, variantTypeString(data.type()), epicsTypeString(*value));
+                                     prec->name, variantTypeString(data.type()), epicsTypeString(value));
                         (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                         ret = 1;
                     } else {
@@ -1081,7 +1081,7 @@ private:
                          prec->name,
                          variantTypeString(incomingData.type()),
                          variantTypeString(targetType),
-                         epicsTypeString(*value));
+                         epicsTypeString(value));
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
         } else {
@@ -1095,7 +1095,7 @@ private:
                 markAsDirty();
             }
 
-            dbgWriteArray(num, epicsTypeString(*value));
+            dbgWriteArray(num, epicsTypeString(value));
         }
         return ret;
     }

--- a/devOpcuaSup/open62541/DataElementOpen62541.cpp
+++ b/devOpcuaSup/open62541/DataElementOpen62541.cpp
@@ -624,7 +624,7 @@ DataElementOpen62541::readArray (char *value, const epicsUInt32 len,
 
     ProcessReason nReason;
     std::shared_ptr<UpdateOpen62541> upd = incomingQueue.popUpdate(&nReason);
-    dbgReadArray(upd.get(), num, epicsTypeString(*value));
+    dbgReadArray(upd.get(), num, epicsTypeString(value));
 
     switch (upd->getType()) {
     case ProcessReason::readFailure:
@@ -653,7 +653,7 @@ DataElementOpen62541::readArray (char *value, const epicsUInt32 len,
                     ret = 1;
                 } else if (data.type != expectedType) {
                     errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                 prec->name, variantTypeString(data), epicsTypeString(*value));
+                                 prec->name, variantTypeString(data), epicsTypeString(value));
                     (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                     ret = 1;
                 } else {
@@ -1048,7 +1048,7 @@ DataElementOpen62541::writeArray (const char **value, const epicsUInt32 len,
                      prec->name,
                      variantTypeString(incomingData),
                      variantTypeString(targetType),
-                     epicsTypeString(**value));
+                     epicsTypeString(*value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1084,7 +1084,7 @@ DataElementOpen62541::writeArray (const char **value, const epicsUInt32 len,
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
             } else {
-                dbgWriteArray(num, epicsTypeString(**value));
+                dbgWriteArray(num, epicsTypeString(*value));
             }
         }
     }

--- a/devOpcuaSup/open62541/DataElementOpen62541.h
+++ b/devOpcuaSup/open62541/DataElementOpen62541.h
@@ -43,17 +43,17 @@ class ItemOpen62541;
 
 typedef Update<UA_Variant, UA_StatusCode> UpdateOpen62541;
 
-inline const char *epicsTypeString (const epicsInt8 &) { return "epicsInt8"; }
-inline const char *epicsTypeString (const epicsUInt8 &) { return "epicsUInt8"; }
-inline const char *epicsTypeString (const epicsInt16 &) { return "epicsInt16"; }
-inline const char *epicsTypeString (const epicsUInt16 &) { return "epicsUInt16"; }
-inline const char *epicsTypeString (const epicsInt32 &) { return "epicsInt32"; }
-inline const char *epicsTypeString (const epicsUInt32 &) { return "epicsUInt32"; }
-inline const char *epicsTypeString (const epicsInt64 &) { return "epicsInt64"; }
-inline const char *epicsTypeString (const epicsUInt64 &) { return "epicsUInt64"; }
-inline const char *epicsTypeString (const epicsFloat32 &) { return "epicsFloat32"; }
-inline const char *epicsTypeString (const epicsFloat64 &) { return "epicsFloat64"; }
-inline const char *epicsTypeString (const char* &) { return "epicsString"; }
+inline const char *epicsTypeString (const epicsInt8 *) { return "epicsInt8"; }
+inline const char *epicsTypeString (const epicsUInt8 *) { return "epicsUInt8"; }
+inline const char *epicsTypeString (const epicsInt16 *) { return "epicsInt16"; }
+inline const char *epicsTypeString (const epicsUInt16 *) { return "epicsUInt16"; }
+inline const char *epicsTypeString (const epicsInt32 *) { return "epicsInt32"; }
+inline const char *epicsTypeString (const epicsUInt32 *) { return "epicsUInt32"; }
+inline const char *epicsTypeString (const epicsInt64 *) { return "epicsInt64"; }
+inline const char *epicsTypeString (const epicsUInt64 *) { return "epicsUInt64"; }
+inline const char *epicsTypeString (const epicsFloat32 *) { return "epicsFloat32"; }
+inline const char *epicsTypeString (const epicsFloat64 *) { return "epicsFloat64"; }
+inline const char *epicsTypeString (const char* ) { return "epicsString"; }
 
 inline const char *
 variantTypeString (const UA_DataType *type)
@@ -805,7 +805,7 @@ private:
 
         ProcessReason nReason;
         std::shared_ptr<UpdateOpen62541> upd = incomingQueue.popUpdate(&nReason);
-        dbgReadScalar(upd.get(), epicsTypeString(*value));
+        dbgReadScalar(upd.get(), epicsTypeString(value));
 
         switch (upd->getType()) {
         case ProcessReason::readFailure:
@@ -960,7 +960,7 @@ private:
 
         ProcessReason nReason;
         std::shared_ptr<UpdateOpen62541> upd = incomingQueue.popUpdate(&nReason);
-        dbgReadArray(upd.get(), num, epicsTypeString(*value));
+        dbgReadArray(upd.get(), num, epicsTypeString(value));
 
         switch (upd->getType()) {
         case ProcessReason::readFailure:
@@ -989,7 +989,7 @@ private:
                         ret = 1;
                     } else if (data.type != expectedType) {
                         errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                     prec->name, variantTypeString(data), epicsTypeString(*value));
+                                     prec->name, variantTypeString(data), epicsTypeString(value));
                         (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                         ret = 1;
                     } else {
@@ -1218,7 +1218,7 @@ private:
                          prec->name,
                          variantTypeString(incomingData),
                          variantTypeString(targetType),
-                         epicsTypeString(*value));
+                         epicsTypeString(value));
             (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
             ret = 1;
         } else {
@@ -1234,7 +1234,7 @@ private:
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
             } else {
-                dbgWriteArray(num, epicsTypeString(*value));
+                dbgWriteArray(num, epicsTypeString(value));
             }
         }
         return ret;

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.Arrays.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.Arrays.db
@@ -12,6 +12,7 @@ record(waveform, "$(P)$(R)wfchar") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfint16") {
@@ -21,6 +22,7 @@ record(waveform, "$(P)$(R)wfint16") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfint32") {
@@ -30,6 +32,7 @@ record(waveform, "$(P)$(R)wfint32") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfuchar") {
@@ -39,6 +42,7 @@ record(waveform, "$(P)$(R)wfuchar") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfuint16") {
@@ -48,6 +52,7 @@ record(waveform, "$(P)$(R)wfuint16") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfuint32") {
@@ -57,6 +62,7 @@ record(waveform, "$(P)$(R)wfuint32") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wffloat") {
@@ -66,6 +72,7 @@ record(waveform, "$(P)$(R)wffloat") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfdouble") {
@@ -75,6 +82,7 @@ record(waveform, "$(P)$(R)wfdouble") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfstring") {
@@ -84,4 +92,5 @@ record(waveform, "$(P)$(R)wfstring") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.ArraysE7.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.ArraysE7.db
@@ -14,6 +14,7 @@ record(waveform, "$(P)$(R)wfint64") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(waveform, "$(P)$(R)wfuint64") {
@@ -23,4 +24,5 @@ record(waveform, "$(P)$(R)wfuint64") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.Scalar.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.Scalar.db
@@ -10,6 +10,7 @@ record(longin, "$(P)$(R)lichar") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.SByte")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)liint16") {
@@ -17,6 +18,7 @@ record(longin, "$(P)$(R)liint16") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Int16")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)liint32") {
@@ -24,6 +26,7 @@ record(longin, "$(P)$(R)liint32") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Int32")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)liuchar") {
@@ -31,6 +34,7 @@ record(longin, "$(P)$(R)liuchar") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Byte")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)liuint16") {
@@ -38,6 +42,7 @@ record(longin, "$(P)$(R)liuint16") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.UInt16")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)liuint32") {
@@ -45,6 +50,7 @@ record(longin, "$(P)$(R)liuint32") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.UInt32")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(ai, "$(P)$(R)aifloat") {
@@ -52,6 +58,7 @@ record(ai, "$(P)$(R)aifloat") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Float")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(ai, "$(P)$(R)aidouble") {
@@ -59,6 +66,7 @@ record(ai, "$(P)$(R)aidouble") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Double")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(ai, "$(P)$(R)aiint32") {
@@ -69,6 +77,7 @@ record(ai, "$(P)$(R)aiint32") {
     field(PREC, "1")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(stringin, "$(P)$(R)sistring") {
@@ -76,4 +85,5 @@ record(stringin, "$(P)$(R)sistring") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.String")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.ScalarE7.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Dynamic.ScalarE7.db
@@ -12,6 +12,7 @@ record(int64in, "$(P)$(R)int64in") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.Int64")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(int64in, "$(P)$(R)uint64in") {
@@ -19,4 +20,5 @@ record(int64in, "$(P)$(R)uint64in") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.UInt64")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Arrays.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Arrays.db
@@ -12,6 +12,7 @@ record(aai, "$(P)$(R)aaichar") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaochar") {
@@ -20,6 +21,7 @@ record(aao, "$(P)$(R)aaochar") {
     field(FTVL, "CHAR")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaiint16") {
@@ -29,6 +31,7 @@ record(aai, "$(P)$(R)aaiint16") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaoint16") {
@@ -37,6 +40,7 @@ record(aao, "$(P)$(R)aaoint16") {
     field(FTVL, "SHORT")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaiint32") {
@@ -46,6 +50,7 @@ record(aai, "$(P)$(R)aaiint32") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaoint32") {
@@ -54,6 +59,7 @@ record(aao, "$(P)$(R)aaoint32") {
     field(FTVL, "LONG")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaiuchar") {
@@ -63,6 +69,7 @@ record(aai, "$(P)$(R)aaiuchar") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaouchar") {
@@ -71,6 +78,7 @@ record(aao, "$(P)$(R)aaouchar") {
     field(FTVL, "UCHAR")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaiuint32") {
@@ -80,6 +88,7 @@ record(aai, "$(P)$(R)aaiuint32") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaouint32") {
@@ -88,6 +97,7 @@ record(aao, "$(P)$(R)aaouint32") {
     field(FTVL, "ULONG")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaifloat") {
@@ -97,6 +107,7 @@ record(aai, "$(P)$(R)aaifloat") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaofloat") {
@@ -105,6 +116,7 @@ record(aao, "$(P)$(R)aaofloat") {
     field(FTVL, "FLOAT")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaidouble") {
@@ -114,6 +126,7 @@ record(aai, "$(P)$(R)aaidouble") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaodouble") {
@@ -122,6 +135,7 @@ record(aao, "$(P)$(R)aaodouble") {
     field(FTVL, "DOUBLE")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaistring") {
@@ -131,6 +145,7 @@ record(aai, "$(P)$(R)aaistring") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaostring") {
@@ -139,4 +154,5 @@ record(aao, "$(P)$(R)aaostring") {
     field(FTVL, "STRING")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ArraysE7.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ArraysE7.db
@@ -14,6 +14,7 @@ record(aai, "$(P)$(R)aaiint64") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaoint64") {
@@ -22,6 +23,7 @@ record(aao, "$(P)$(R)aaoint64") {
     field(FTVL, "INT64")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aai, "$(P)$(R)aaiuint64") {
@@ -31,6 +33,7 @@ record(aai, "$(P)$(R)aaiuint64") {
     field(NELM, "10")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(aao, "$(P)$(R)aaouint64") {
@@ -39,4 +42,5 @@ record(aao, "$(P)$(R)aaouint64") {
     field(FTVL, "UINT64")
     field(NELM, "10")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Scalar.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Scalar.db
@@ -15,6 +15,7 @@ record(bi, "$(P)$(R)bibool") {
     field(ONAM, "true")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(bo, "$(P)$(R)bobool") {
@@ -23,6 +24,7 @@ record(bo, "$(P)$(R)bobool") {
     field(ZNAM, "false")
     field(ONAM, "true")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(bi, "$(P)$(R)biboolx") {
@@ -32,6 +34,7 @@ record(bi, "$(P)$(R)biboolx") {
     field(ONAM, "true")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(bo, "$(P)$(R)boboolx") {
@@ -40,6 +43,7 @@ record(bo, "$(P)$(R)boboolx") {
     field(ZNAM, "false")
     field(ONAM, "true")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # mbbi/mbbo  -  Byte
@@ -59,6 +63,7 @@ record(mbbi, "$(P)$(R)mbbibyte") {
     field(NIST, "nine")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(mbbo, "$(P)$(R)mbbobyte") {
@@ -75,6 +80,7 @@ record(mbbo, "$(P)$(R)mbbobyte") {
     field(EIST, "eight")
     field(NIST, "nine")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(longin, "$(P)$(R)libyte") {
@@ -82,6 +88,7 @@ record(longin, "$(P)$(R)libyte") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.Byte")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # mbbiDirect/mbboDirect  -  UInt32
@@ -91,12 +98,14 @@ record(mbbiDirect, "$(P)$(R)mbbiduint32") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.UInt32")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(mbboDirect, "$(P)$(R)mbboduint32") {
     field(DTYP, "OPCUA")
     field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.UInt32")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # ai/ao  -  Double
@@ -106,12 +115,14 @@ record(ai, "$(P)$(R)aidouble") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.Double")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(ao, "$(P)$(R)aodouble") {
     field(DTYP, "OPCUA")
     field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.Double")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # ai/ao  -  int32 (using linear conversion)
@@ -124,6 +135,7 @@ record(ai, "$(P)$(R)aiint32") {
     field(EGUF, "1e3")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(ao, "$(P)$(R)aoint32") {
@@ -133,6 +145,7 @@ record(ao, "$(P)$(R)aoint32") {
     field(EGUL, "-1e3")
     field(EGUF, "1e3")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # si/so  -  String
@@ -142,10 +155,12 @@ record(stringin, "$(P)$(R)sistring") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(stringout, "$(P)$(R)sostring") {
     field(DTYP, "OPCUA")
     field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Scalar.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.Scalar.db
@@ -139,13 +139,13 @@ record(ao, "$(P)$(R)aoint32") {
 
 record(stringin, "$(P)$(R)sistring") {
     field(DTYP, "OPCUA")
-    field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.String")
+    field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
 }
 
 record(stringout, "$(P)$(R)sostring") {
     field(DTYP, "OPCUA")
-    field(OUT,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.String")
+    field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(TSE,  "-2")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ScalarE7.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ScalarE7.db
@@ -26,13 +26,13 @@ record(int64out, "$(P)$(R)int64out") {
 
 record(lsi, "$(P)$(R)lsistring") {
     field(DTYP, "OPCUA")
-    field(INP,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.String")
+    field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
 }
 
 record(lso, "$(P)$(R)lsostring") {
     field(DTYP, "OPCUA")
-    field(OUT,  "@$(SUBS) ns=2;s=Demo.Dynamic.Scalar.String")
+    field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(TSE,  "-2")
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ScalarE7.db
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.Static.ScalarE7.db
@@ -14,12 +14,14 @@ record(int64in, "$(P)$(R)int64in") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.Int64")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(int64out, "$(P)$(R)int64out") {
     field(DTYP, "OPCUA")
     field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.Int64")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 # lsi/lso  -  String
@@ -29,10 +31,12 @@ record(lsi, "$(P)$(R)lsistring") {
     field(INP,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(SCAN, "I/O Intr")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }
 
 record(lso, "$(P)$(R)lsostring") {
     field(DTYP, "OPCUA")
     field(OUT,  "@$(SUBS) ns=2;s=Demo.Static.Scalar.String")
     field(TSE,  "-2")
+    field(TPRO, "$(DEBUG=0)")
 }


### PR DESCRIPTION
When compiled with -O0, the program actually evaluates `*value` in `epicsTypeString(*value))` which crashes if `value==nullptr` (during initialization).
When compiled with at least -O1, the compiler never evaluates `*value` because `epicsTypeString` does not actually use it. Thus the program did not crash.
This fix changes all `epicsTypeString(*value)` to `epicsTypeString(value)`, so that `*value` is never evaluated in this context.