### PR TITLE
make substitution files compatible with dbLoadTemplate

### DIFF
--- a/exampleTop/DeviceDbApp/S7-1500Db/S7-1500-server.substitutions
+++ b/exampleTop/DeviceDbApp/S7-1500Db/S7-1500-server.substitutions
@@ -1,7 +1,7 @@
 file opcuaServerInfo.template {
-{ P=$(P=), R=$(R=), SESS=$(SESS) }
+{ P="$(P=)", R="$(R=)", SESS=$(SESS) }
 }
 
 file opcuaServerStats.template {
-{ P=$(P=), R=$(R=), SESS=$(SESS), SUBS=$(SUBS) }
+{ P="$(P=)", R="$(R=)", SESS=$(SESS), SUBS=$(SUBS) }
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrder.substitutions
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/Demo.WorkOrder.substitutions
@@ -1,4 +1,4 @@
 file Demo.WorkOrderVariable.template {
-{ P=$(P=), R=WOVAR:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable }
-{ P=$(P=), R=WOVAR2:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable2 }
+{ P="$(P=)", R=WOVAR:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable }
+{ P="$(P=)", R=WOVAR2:, SESS=$(SESS), SUBS=$(SUBS), WO_NODEID=Demo.WorkOrder.WorkOrderVariable2 }
 }

--- a/exampleTop/DeviceDbApp/UaDemoServerDb/UaDemoServer-server.substitutions
+++ b/exampleTop/DeviceDbApp/UaDemoServerDb/UaDemoServer-server.substitutions
@@ -1,7 +1,7 @@
 file opcuaServerInfo.template {
-{ P=$(P=), R=$(R=), SESS=$(SESS) }
+{ P="$(P=)", R="$(R=)", SESS=$(SESS) }
 }
 
 file opcuaServerStats.template {
-{ P=$(P=), R=$(R=), SESS=$(SESS), SUBS=$(SUBS) }
+{ P="$(P=)", R="$(R=)", SESS=$(SESS), SUBS=$(SUBS) }
 }


### PR DESCRIPTION
`dbLoadTemplate` requires that macro values containing macro defaults are quoted. (msi does not need this.)
