### PR TITLE
Add Sliding Average Statistics and Improve iocsh Integration

### DIFF
--- a/.ci-local/install-open62541.py
+++ b/.ci-local/install-open62541.py
@@ -86,14 +86,18 @@ OPEN62541_USE_XMLPARSER = YES'''.format(installdir))
     if cue.ci['static']:
         build_shared = 'OFF'
 
-    sp.check_call(['cmake', '..',
-                   '-G', generator,
-                   '-DBUILD_SHARED_LIBS={0}'.format(build_shared),
-                   '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
-                   '-DUA_ENABLE_ENCRYPTION=OPENSSL',
-                   '-DUA_ENABLE_ENCRYPTION_OPENSSL=ON',
-                   '-DCMAKE_INSTALL_PREFIX={0}'.format(installdir)],
-                   cwd=builddir)
+    cmake_args = ['cmake', '..',
+                  '-G', generator,
+                  '-DBUILD_SHARED_LIBS={0}'.format(build_shared),
+                  '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+                  '-DUA_ENABLE_ENCRYPTION=OPENSSL',
+                  '-DUA_ENABLE_ENCRYPTION_OPENSSL=ON',
+                  '-DCMAKE_INSTALL_PREFIX={0}'.format(installdir)]
+
+    if cue.ci['os'] == 'windows' and cue.ci['compiler'] == 'gcc':
+        cmake_args.append('-DCMAKE_C_FLAGS=-Wno-error=jump-misses-init')
+
+    sp.check_call(cmake_args, cwd=builddir)
 
     sp.check_call(['cmake', '--build', '.', '--config', 'RelWithDebInfo'], cwd=builddir)
     sp.check_call(['cmake', '--install', '.', '--config', 'RelWithDebInfo'], cwd=builddir)

--- a/devOpcuaSup/DevOpcuaRegistry.h
+++ b/devOpcuaSup/DevOpcuaRegistry.h
@@ -8,8 +8,8 @@
  *  Author: Ralph Lange <ralph.lange@gmx.de>
  */
 
-#ifndef DEVOPCUA_REGISTRY_H
-#define DEVOPCUA_REGISTRY_H
+#ifndef DEVOPCUA_DEVOPCUAREGISTRY_H
+#define DEVOPCUA_DEVOPCUAREGISTRY_H
 
 #include <set>
 #include <map>
@@ -158,4 +158,4 @@ private:
 
 } // namespace DevOpcua
 
-#endif // DEVOPCUA_REGISTRY_H
+#endif // DEVOPCUA_DEVOPCUAREGISTRY_H

--- a/devOpcuaSup/Makefile
+++ b/devOpcuaSup/Makefile
@@ -59,6 +59,7 @@ opcua_SRCS += iocshIntegration.cpp
 opcua_SRCS += RecordConnector.cpp
 opcua_SRCS += linkParser.cpp
 opcua_SRCS += opcuaItemRecord.cpp
+opcua_SRCS += Stats.cpp
 
 opcua_LIBS += $(EPICS_BASE_IOC_LIBS)
 

--- a/devOpcuaSup/Stats.cpp
+++ b/devOpcuaSup/Stats.cpp
@@ -1,0 +1,328 @@
+/*************************************************************************\
+* Copyright (c) 2025 ITER Organization.
+* This module is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/*
+ *  Author: Ralph Lange <ralph.lange@gmx.de>
+ */
+
+#include "Stats.h"
+
+#include <algorithm>
+#include <iomanip>
+
+#include <epicsString.h>
+
+namespace DevOpcua {
+
+StatsCounter::StatsCounter()
+    : value(0)
+{}
+
+void StatsCounter::increment(long long val)
+{
+    value.fetch_add(val, std::memory_order_relaxed);
+}
+
+void StatsCounter::set(long long val)
+{
+    value.store(val, std::memory_order_relaxed);
+}
+
+long long StatsCounter::get() const
+{
+    return value.load(std::memory_order_relaxed);
+}
+
+void StatsCounter::reset()
+{
+    set(0);
+}
+
+StatsHistogram::StatsHistogram(const std::vector<double> &buckets)
+    : buckets(buckets)
+{
+    counts.resize(buckets.size() + 1);
+    for (auto &count : counts) {
+        count = std::make_shared<std::atomic<long long>>();
+    }
+}
+
+void StatsHistogram::record(const double value)
+{
+    auto it = std::lower_bound(buckets.begin(), buckets.end(), value);
+    size_t index = std::distance(buckets.begin(), it);
+    counts[index]->fetch_add(1, std::memory_order_relaxed);
+}
+
+void StatsHistogram::print(std::ostream &os) const
+{
+    for (size_t i = 0; i < buckets.size(); ++i) {
+        if (i == 0) {
+            os << "                    <= " << std::setw(10) << buckets[i] << " us: " << counts[i]->load()
+               << std::endl;
+        } else {
+            os << "  >  " << std::setw(10) << buckets[i - 1] << " and <= " << std::setw(10)
+               << buckets[i] << " us: " << counts[i]->load() << std::endl;
+        }
+    }
+    os << "                    >  " << std::setw(10) << buckets.back() << " us: " << counts.back()->load()
+       << std::endl;
+}
+
+void StatsHistogram::reset()
+{
+    for (auto &count : counts) {
+        count->store(0, std::memory_order_relaxed);
+    }
+}
+
+StatsSlidingAverage::StatsSlidingAverage(size_t windowSize)
+    : windowSize(windowSize > 0 ? windowSize : 1)
+    , nextIndex(0)
+    , count(0)
+{
+    buffer.resize(this->windowSize);
+}
+
+void StatsSlidingAverage::record(double value)
+{
+    Guard G(lock);
+    buffer[nextIndex] = value;
+    nextIndex = (nextIndex + 1) % windowSize;
+    if (count < windowSize)
+        count++;
+}
+
+void StatsSlidingAverage::reset()
+{
+    Guard G(lock);
+    nextIndex = 0;
+    count = 0;
+}
+
+double StatsSlidingAverage::getAverage() const
+{
+    Guard G(lock);
+    if (count == 0)
+        return 0.0;
+    double sum = 0.0;
+    for (size_t i = 0; i < count; ++i) {
+        sum += buffer[i];
+    }
+    return sum / count;
+}
+
+double StatsSlidingAverage::getMedian() const
+{
+    Guard G(lock);
+    if (count == 0)
+        return 0.0;
+    std::vector<double> sorted(buffer.begin(), buffer.begin() + count);
+    std::sort(sorted.begin(), sorted.end());
+    if (count % 2 == 0) {
+        return (sorted[count / 2 - 1] + sorted[count / 2]) / 2.0;
+    } else {
+        return sorted[count / 2];
+    }
+}
+
+double StatsSlidingAverage::getMin() const
+{
+    Guard G(lock);
+    if (count == 0)
+        return 0.0;
+    double minVal = buffer[0];
+    for (size_t i = 1; i < count; ++i) {
+        if (buffer[i] < minVal)
+            minVal = buffer[i];
+    }
+    return minVal;
+}
+
+double StatsSlidingAverage::getMax() const
+{
+    Guard G(lock);
+    if (count == 0)
+        return 0.0;
+    double maxVal = buffer[0];
+    for (size_t i = 1; i < count; ++i) {
+        if (buffer[i] > maxVal)
+            maxVal = buffer[i];
+    }
+    return maxVal;
+}
+
+void StatsSlidingAverage::print(std::ostream &os, int verbosity) const
+{
+    Guard G(lock);
+    os << "    Average: " << getAverage() << std::endl;
+    if (verbosity > 0) {
+        os << "    Median:  " << getMedian() << std::endl;
+        os << "    Min:     " << getMin() << std::endl;
+        os << "    Max:     " << getMax() << std::endl;
+        os << "    Count:   " << count << " (window: " << windowSize << ")" << std::endl;
+    }
+}
+
+StatsExecTime::StatsExecTime(const std::vector<double> &buckets)
+    : totalExecutionTime(0)
+    , count(0)
+    , histogram(buckets.empty()
+                    ? std::vector<double>{1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000}
+                    : buckets)
+{}
+
+void StatsExecTime::record(const long long nanoseconds)
+{
+    totalExecutionTime.fetch_add(nanoseconds, std::memory_order_relaxed);
+    count.fetch_add(1, std::memory_order_relaxed);
+    histogram.record(static_cast<double>(nanoseconds) / 1e3); // Record in microseconds
+}
+
+void StatsExecTime::reset()
+{
+    totalExecutionTime.store(0);
+    count.store(0);
+    histogram.reset();
+}
+
+long long StatsExecTime::getTotalExecutionTimeNs() const
+{
+    return totalExecutionTime.load(std::memory_order_relaxed);
+}
+
+long long StatsExecTime::getCount() const
+{
+    return count.load(std::memory_order_relaxed);
+}
+
+double StatsExecTime::getAverageTimeUs() const
+{
+    long long count = getCount();
+    if (count == 0)
+        return 0.0;
+    return (static_cast<double>(getTotalExecutionTimeNs()) / 1000.) / static_cast<double>(count);
+}
+
+void StatsExecTime::print(std::ostream &os) const
+{
+    os << "    Total Exec Time: " << static_cast<double>(getTotalExecutionTimeNs()) / 1e9 << " s"
+       << std::endl;
+    os << "    Count: " << getCount() << std::endl;
+    os << "    Average Time: " << getAverageTimeUs() << " us" << std::endl;
+    os << "    Histogram (us):" << std::endl;
+    histogram.print(os);
+}
+
+StatsTimer::StatsTimer(std::shared_ptr<StatsExecTime> stats)
+    : stats(stats)
+    , startTime(std::chrono::high_resolution_clock::now())
+{}
+
+StatsTimer::~StatsTimer()
+{
+    auto endTime = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
+    stats->record(duration);
+}
+
+StatsManager &StatsManager::getInstance()
+{
+    static StatsManager instance;
+    return instance;
+}
+
+std::shared_ptr<StatsCounter> StatsManager::getCounter(const std::string &name)
+{
+    Guard G(lock);
+    if (counters.find(name) == counters.end()) {
+        counters[name] = std::make_shared<StatsCounter>();
+    }
+    return counters[name];
+}
+
+std::shared_ptr<StatsExecTime> StatsManager::getExecutionStats(
+    const std::string &name, const std::vector<double> &histogram_buckets)
+{
+    Guard G(lock);
+    if (execTimes.find(name) == execTimes.end()) {
+        execTimes[name] = std::make_shared<StatsExecTime>(histogram_buckets);
+    }
+    return execTimes[name];
+}
+
+std::shared_ptr<StatsSlidingAverage> StatsManager::getSlidingAverage(
+    const std::string &name, size_t windowSize)
+{
+    Guard G(lock);
+    if (slidingAverages.find(name) == slidingAverages.end()) {
+        slidingAverages[name] = std::make_shared<StatsSlidingAverage>(windowSize);
+    }
+    return slidingAverages[name];
+}
+
+void StatsManager::report(std::ostream &os, int verbosity, const std::string &pattern) const
+{
+    Guard G(lock);
+    os << "--- Statistics Report ---" << std::endl;
+
+    os << "\n-- Counters --" << std::endl;
+    for (const auto& pair : counters) {
+        if (epicsStrGlobMatch(pair.first.c_str(), pattern.c_str()))
+            os << pair.first << ": " << pair.second->get() << std::endl;
+    }
+
+    os << "\n-- Execution Timers --" << std::endl;
+    for (const auto &pair : execTimes) {
+        if (epicsStrGlobMatch(pair.first.c_str(), pattern.c_str())) {
+            os << pair.first << ":" << std::endl;
+            pair.second->print(os);
+        }
+    }
+
+    os << "\n-- Sliding Averages --" << std::endl;
+    for (const auto &pair : slidingAverages) {
+        if (epicsStrGlobMatch(pair.first.c_str(), pattern.c_str())) {
+            os << pair.first << ":" << std::endl;
+            pair.second->print(os, verbosity);
+        }
+    }
+
+    os << "-------------------------" << std::endl;
+}
+
+void StatsManager::reset(const std::string &name)
+{
+    Guard G(lock);
+    for (auto &pair : counters) {
+        if (epicsStrGlobMatch(pair.first.c_str(), name.c_str()))
+            pair.second->reset();
+    }
+    for (auto &pair : execTimes) {
+        if (epicsStrGlobMatch(pair.first.c_str(), name.c_str()))
+            pair.second->reset();
+    }
+    for (auto &pair : slidingAverages) {
+        if (epicsStrGlobMatch(pair.first.c_str(), name.c_str()))
+            pair.second->reset();
+    }
+}
+
+void StatsManager::reset_all()
+{
+    Guard G(lock);
+    for (auto &pair : counters) {
+        pair.second->reset();
+    }
+    for (auto &pair : execTimes) {
+        pair.second->reset();
+    }
+    for (auto &pair : slidingAverages) {
+        pair.second->reset();
+    }
+}
+
+} // namespace DevOpcua

--- a/devOpcuaSup/Stats.h
+++ b/devOpcuaSup/Stats.h
@@ -22,10 +22,10 @@
 #include <epicsGuard.h>
 #include <epicsMutex.h>
 
+namespace DevOpcua {
+
 typedef epicsGuard<epicsMutex> Guard;
 typedef epicsGuardRelease<epicsMutex> UnGuard;
-
-namespace DevOpcua {
 
 /**
  * @brief A simple thread-safe counter.

--- a/devOpcuaSup/Stats.h
+++ b/devOpcuaSup/Stats.h
@@ -8,8 +8,8 @@
  *  Author: Ralph Lange <ralph.lange@gmx.de>
  */
 
-#ifndef STATS_H
-#define STATS_H
+#ifndef DEVOPCUA_STATS_H
+#define DEVOPCUA_STATS_H
 
 #include <atomic>
 #include <chrono>
@@ -169,8 +169,8 @@ public:
     /**
      * @brief Prints a report of all matching statistics to the given output stream.
      * @param os Output stream to print to.
-     * @param verbosity Amount of printed information.
      * @param pattern Glob pattern to match.
+     * @param verbosity Amount of printed information.
      */
     void report(std::ostream &os, int verbosity = 0, const std::string &pattern = "*") const;
 
@@ -191,4 +191,4 @@ private:
 
 } // namespace DevOpcua
 
-#endif // STATS_H
+#endif // DEVOPCUA_STATS_H

--- a/devOpcuaSup/Stats.h
+++ b/devOpcuaSup/Stats.h
@@ -1,0 +1,194 @@
+/*************************************************************************\
+* Copyright (c) 2025 ITER Organization.
+* This module is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/*
+ *  Author: Ralph Lange <ralph.lange@gmx.de>
+ */
+
+#ifndef STATS_H
+#define STATS_H
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <epicsGuard.h>
+#include <epicsMutex.h>
+
+typedef epicsGuard<epicsMutex> Guard;
+typedef epicsGuardRelease<epicsMutex> UnGuard;
+
+namespace DevOpcua {
+
+/**
+ * @brief A simple thread-safe counter.
+ */
+class StatsCounter
+{
+public:
+    StatsCounter();
+
+    void increment(long long val = 1);
+    void set(long long val);
+
+    long long get() const;
+    void reset();
+
+private:
+    std::atomic<long long> value;
+};
+
+/**
+ * @brief A thread-safe histogram for storing execution time distributions.
+ */
+class StatsHistogram
+{
+public:
+    StatsHistogram(const std::vector<double> &buckets);
+
+    void record(const double value);
+
+    void print(std::ostream &os) const;
+    void reset();
+
+private:
+    std::vector<double> buckets;
+    std::vector<std::shared_ptr<std::atomic<long long>>> counts;
+};
+
+/**
+ * @brief A thread-safe sliding average collector.
+ */
+class StatsSlidingAverage
+{
+public:
+    StatsSlidingAverage(size_t windowSize);
+
+    void record(double value);
+    void reset();
+
+    double getAverage() const;
+    double getMedian() const;
+    double getMin() const;
+    double getMax() const;
+
+    void print(std::ostream &os, int verbosity = 0) const;
+
+private:
+    size_t windowSize;
+    std::vector<double> buffer;
+    size_t nextIndex;
+    size_t count;
+    mutable epicsMutex lock;
+};
+
+/**
+ * @brief Collects and calculates statistics for execution times.
+ */
+class StatsExecTime
+{
+public:
+    StatsExecTime(const std::vector<double> &buckets);
+
+    void record(const long long nanoseconds);
+    void reset();
+
+    long long getTotalExecutionTimeNs() const;
+    long long getCount() const;
+    double getAverageTimeUs() const;
+    void print(std::ostream &os) const;
+
+private:
+    std::atomic<long long> totalExecutionTime;
+    std::atomic<long long> count;
+    StatsHistogram histogram;
+};
+
+/**
+ * @brief An RAII-style timer to measure execution time of a scope.
+ */
+class StatsTimer
+{
+public:
+    explicit StatsTimer(std::shared_ptr<StatsExecTime> stats);
+    ~StatsTimer();
+
+private:
+    std::shared_ptr<StatsExecTime> stats;
+    std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
+};
+
+/**
+ * @brief Thread-safe singleton for creating and managing named statistics.
+ *
+ * Provides a central point of access for all statistics in the application.
+ * Ensures that statistics are uniquely named
+ * and that access to them is thread-safe.
+ */
+class StatsManager
+{
+public:
+    /**
+     * @brief Gets the singleton instance of the registry.
+     * @return Reference to the singleton StatsManager instance.
+     */
+    static StatsManager &getInstance();
+
+    /**
+     * @brief Gets or creates a named counter.
+     * @param name Name of the counter.
+     * @return Shared pointer to the Counter.
+     */
+    std::shared_ptr<StatsCounter> getCounter(const std::string &name);
+
+    /**
+     * @brief Gets or creates a named execution statistics collector.
+     * @param name Name of the execution statistics.
+     * @param histogram_buckets A vector of upper bounds for the histogram buckets in microseconds.
+     * @return A shared pointer to the ExecutionStats.
+     */
+    std::shared_ptr<StatsExecTime> getExecutionStats(
+        const std::string &name, const std::vector<double> &histogram_buckets = {});
+
+    /**
+     * @brief Gets or creates a named sliding average statistics collector.
+     * @param name Name of the sliding average statistics.
+     * @param windowSize Number of values to average over.
+     * @return A shared pointer to the SlidingAverage.
+     */
+    std::shared_ptr<StatsSlidingAverage> getSlidingAverage(
+        const std::string &name, size_t windowSize = 100);
+
+    /**
+     * @brief Prints a report of all matching statistics to the given output stream.
+     * @param os Output stream to print to.
+     * @param verbosity Amount of printed information.
+     * @param pattern Glob pattern to match.
+     */
+    void report(std::ostream &os, int verbosity = 0, const std::string &pattern = "*") const;
+
+    void reset(const std::string &name);
+    void reset_all();
+
+private:
+    StatsManager() = default;
+    ~StatsManager() = default;
+    StatsManager(const StatsManager &) = delete;
+    StatsManager &operator=(const StatsManager &) = delete;
+
+    mutable epicsMutex lock;
+    std::unordered_map<std::string, std::shared_ptr<StatsCounter>> counters;
+    std::unordered_map<std::string, std::shared_ptr<StatsExecTime>> execTimes;
+    std::unordered_map<std::string, std::shared_ptr<StatsSlidingAverage>> slidingAverages;
+};
+
+} // namespace DevOpcua
+
+#endif // STATS_H

--- a/devOpcuaSup/UaSdk/DataElementUaSdkNode.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdkNode.cpp
@@ -30,6 +30,7 @@
 #include <errlog.h>
 
 #include "ItemUaSdk.h"
+#include "Stats.h"
 #include "RecordConnector.h"
 
 namespace DevOpcua {
@@ -170,16 +171,24 @@ DataElementUaSdkNode::setIncomingData (const UaVariant &value,
         if (extensionObject.encoding() == UaExtensionObject::EncodeableObject)
             extensionObject.changeEncoding(UaExtensionObject::Binary);
 
-        UaStructureDefinition definition = pitem->structureDefinition(extensionObject.encodingTypeId());
+        static auto catalog_timer(StatsManager::getInstance().getExecutionStats(
+            "catalog_query", std::vector<double>{100, 200, 500, 1000, 2000, 5000, 10000}));
+
+        UaStructureDefinition definition;
+        {
+            StatsTimer t(catalog_timer);
+            definition = pitem->structureDefinition(extensionObject.encodingTypeId());
+        }
         if (definition.isNull()) {
-            errlogPrintf("Cannot get a structure definition for item %s element %s (dataTypeId %s "
-                         "encodingTypeId %s) - check "
-                         "access to type "
-                         "dictionary\n",
-                         pitem->nodeid->toString().toUtf8(),
-                         name.c_str(),
-                         extensionObject.dataTypeId().toString().toUtf8(),
-                         extensionObject.encodingTypeId().toString().toUtf8());
+            errlogPrintf(
+                "Cannot get a structure definition for item %s element %s (dataTypeId %s "
+                "encodingTypeId %s) - check "
+                "access to type "
+                "dictionary\n",
+                pitem->nodeid->toString().toUtf8(),
+                name.c_str(),
+                extensionObject.dataTypeId().toString().toUtf8(),
+                extensionObject.encodingTypeId().toString().toUtf8());
             return;
         }
 

--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -14,7 +14,6 @@
 #include "ItemUaSdk.h"
 
 #include <iostream>
-#include <memory>
 
 #include <opcua_statuscodes.h>
 #include <uaclientsdk.h>
@@ -23,6 +22,7 @@
 #include "DataElementUaSdk.h"
 #include "RecordConnector.h"
 #include "SessionUaSdk.h"
+#include "Stats.h"
 #include "SubscriptionUaSdk.h"
 #include "devOpcua.h"
 #include "opcuaItemRecord.h"
@@ -177,7 +177,11 @@ ItemUaSdk::setIncomingData (const OpcUa_DataValue &value, ProcessReason reason, 
 
     setLastStatus(value.StatusCode);
 
+    static auto dissect_timer(StatsManager::getInstance().getExecutionStats(
+        "dissect", std::vector<double>{100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000}));
+
     if (auto pd = dataTree.root().lock()) {
+        StatsTimer t(dissect_timer);
         const std::string *timefrom = nullptr;
         if (linkinfo.timestamp == LinkOptionTimestamp::data && linkinfo.timestampElement.length())
             timefrom = &linkinfo.timestampElement;

--- a/devOpcuaSup/UaSdk/Session.cpp
+++ b/devOpcuaSup/UaSdk/Session.cpp
@@ -27,7 +27,7 @@
 #define epicsExportSharedSymbols
 #include "Session.h"
 #include "SessionUaSdk.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 
 #define st(s) #s
 #define str(s) st(s)

--- a/devOpcuaSup/UaSdk/SessionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SessionUaSdk.h
@@ -32,7 +32,7 @@
 
 #include "RequestQueueBatcher.h"
 #include "Session.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "DataElement.h"
 
 namespace DevOpcua {

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.cpp
@@ -33,7 +33,7 @@
 #include "SubscriptionUaSdk.h"
 #include "RecordConnector.h"
 #include "DataElementUaSdk.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "devOpcua.h"
 
 namespace DevOpcua {

--- a/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
+++ b/devOpcuaSup/UaSdk/SubscriptionUaSdk.h
@@ -27,7 +27,7 @@
 
 #include "SessionUaSdk.h"
 #include "Subscription.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 
 namespace DevOpcua {
 

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -34,6 +34,7 @@
 #include "Subscription.h"
 #include "Registry.h"
 #include "RecordConnector.h"
+#include "Stats.h"
 
 namespace DevOpcua {
 
@@ -374,11 +375,11 @@ const char opcuaShowUsage[]
       "verbosity  amount of printed information (default 0 = sparse)\n";
 
 static const iocshFuncDef opcuaShowFuncDef = {"opcuaShow",
-                                              2,
-                                              opcuaShowArg
+    2,
+    opcuaShowArg
 #ifdef IOCSHFUNCDEF_HAS_USAGE
-                                              ,
-                                              opcuaShowUsage
+    ,
+    opcuaShowUsage
 #endif
 };
 
@@ -413,6 +414,57 @@ opcuaShowCallFunc(const iocshArgBuf *args)
         }
         if (!foundSomething)
             errlogPrintf("No matches for pattern '%s'\n", args[0].sval);
+    }
+}
+
+static const iocshArg opcuaStatsArg0 = {"pattern", iocshArgString};
+static const iocshArg opcuaStatsArg1 = {"verbosity", iocshArgInt};
+
+static const iocshArg *const opcuaStatsArg[2] = {&opcuaStatsArg0, &opcuaStatsArg1};
+
+const char opcuaStatsUsage[]
+    = "Prints statistics about sessions, subscriptions, items and their related data elements.\n\n"
+      "pattern    glob pattern (supports * and ?) for statistics item (default *)\n"
+      "verbosity  amount of printed information (default 0 = sparse)\n";
+
+static const iocshFuncDef opcuaStatsFuncDef = {"opcuaStats",
+                                               2,
+                                               opcuaStatsArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                               ,
+                                               opcuaStatsUsage
+#endif
+};
+
+static void opcuaStatsCallFunc(const iocshArgBuf *args)
+{
+    std::string glob = (args[0].sval == NULL || args[0].sval[0] == '\0') ? "*" : args[0].sval;
+    StatsManager::getInstance().report(std::cout, args[1].ival, glob);
+}
+
+static const iocshArg opcuaStatsResetArg0 = {"pattern", iocshArgString};
+
+static const iocshArg *const opcuaStatsResetArg[1] = {&opcuaStatsResetArg0};
+
+const char opcuaStatsResetUsage[]
+    = "Resets statistics for matching items.\n\n"
+      "pattern    glob pattern (supports * and ?) for statistics item (default all)\n";
+
+static const iocshFuncDef opcuaStatsResetFuncDef = {"opcuaStatsReset",
+                                                    1,
+                                                    opcuaStatsResetArg
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                                    ,
+                                                    opcuaStatsResetUsage
+#endif
+};
+
+static void opcuaStatsResetCallFunc(const iocshArgBuf *args)
+{
+    if (args[0].sval == NULL || args[0].sval[0] == '\0') {
+        StatsManager::getInstance().reset_all();
+    } else {
+        StatsManager::getInstance().reset(args[0].sval);
     }
 }
 
@@ -1085,6 +1137,8 @@ void opcuaIocshRegister ()
     iocshRegister(&opcuaSubscriptionFuncDef, opcuaSubscriptionCallFunc);
     iocshRegister(&opcuaOptionsFuncDef, opcuaOptionsCallFunc);
     iocshRegister(&opcuaShowFuncDef, opcuaShowCallFunc);
+    iocshRegister(&opcuaStatsFuncDef, opcuaStatsCallFunc);
+    iocshRegister(&opcuaStatsResetFuncDef, opcuaStatsResetCallFunc);
 
     iocshRegister(&opcuaConnectFuncDef, opcuaConnectCallFunc);
     iocshRegister(&opcuaDisconnectFuncDef, opcuaDisconnectCallFunc);

--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -32,7 +32,7 @@
 #include "linkParser.h"
 #include "Session.h"
 #include "Subscription.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "RecordConnector.h"
 #include "Stats.h"
 

--- a/devOpcuaSup/open62541/Session.cpp
+++ b/devOpcuaSup/open62541/Session.cpp
@@ -13,7 +13,7 @@
 #define epicsExportSharedSymbols
 #include "SessionOpen62541.h"
 #include "Session.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "devOpcua.h"
 
 #include <epicsThread.h>

--- a/devOpcuaSup/open62541/SessionOpen62541.h
+++ b/devOpcuaSup/open62541/SessionOpen62541.h
@@ -14,7 +14,7 @@
 #define DEVOPCUA_SESSIONOPEN62541_H
 
 #include "Session.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "RequestQueueBatcher.h"
 
 #include <epicsMutex.h>

--- a/devOpcuaSup/open62541/SubscriptionOpen62541.cpp
+++ b/devOpcuaSup/open62541/SubscriptionOpen62541.cpp
@@ -14,7 +14,7 @@
 #include "SubscriptionOpen62541.h"
 #include "ItemOpen62541.h"
 #include "RecordConnector.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 #include "devOpcua.h"
 
 #include <errlog.h>

--- a/devOpcuaSup/open62541/SubscriptionOpen62541.h
+++ b/devOpcuaSup/open62541/SubscriptionOpen62541.h
@@ -14,7 +14,7 @@
 #define DEVOPCUA_SUBSCRIPTIONOPEN62541_H
 
 #include "Subscription.h"
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 
 #include <open62541/client.h>
 

--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -19,8 +19,6 @@ CLIENT_SRC = $(DEVSUP_SRC)/$(CLIENT_SUBDIR)
 
 # Add client specific tests
 SRC_DIRS += $(TESTSRC)/$(CLIENT_SUBDIR)
-# Location of the library classes under test
-SRC_DIRS += $(DEVSUP_SRC) $(CLIENT_SRC)
 USR_INCLUDES += -I$(DEVSUP_SRC) -I$(CLIENT_SRC)
 
 ifeq ($(CLIENT)_USE_CRYPTO),YES)
@@ -34,10 +32,6 @@ USR_INCLUDES += -I$(MSYSTEM_PREFIX)/include/libxml2
 USR_SYS_LIBS += xml2
 endif
 endif
-
-# Link explicitly against locally compiled library objects
-OPCUA_OBJS += linkParser iocshIntegration $($(CLIENT)_OPCUA_OBJS)
-OPCUA_OBJS += RecordConnector Session Subscription
 
 #==================================================
 # Build tests executables
@@ -60,16 +54,12 @@ GTESTS += RegistryTest
 
 GTESTPROD_HOST += LinkParserTest
 LinkParserTest_SRCS += LinkParserTest.cpp
-LinkParserTest_LIBS += $($(CLIENT)_LIBS) $(EPICS_BASE_IOC_LIBS)
-LinkParserTest_SYS_LIBS_Linux += $(OPCUA_SYS_LIBS_Linux)
-LinkParserTest_OBJS += $(OPCUA_OBJS)
+LinkParserTest_LIBS += opcua
 GTESTS += LinkParserTest
 
 GTESTPROD_HOST += ElementTreeTest
 ElementTreeTest_SRCS += ElementTreeTest.cpp
-ElementTreeTest_LIBS += $($(CLIENT)_LIBS) $(EPICS_BASE_IOC_LIBS)
-ElementTreeTest_SYS_LIBS_Linux += $(OPCUA_SYS_LIBS_Linux)
-ElementTreeTest_OBJS += $(OPCUA_OBJS)
+ElementTreeTest_LIBS += opcua
 GTESTS += ElementTreeTest
 
 #==================================================

--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -19,6 +19,7 @@ CLIENT_SRC = $(DEVSUP_SRC)/$(CLIENT_SUBDIR)
 
 # Add client specific tests
 SRC_DIRS += $(TESTSRC)/$(CLIENT_SUBDIR)
+SRC_DIRS += $(DEVSUP_SRC)
 USR_INCLUDES += -I$(DEVSUP_SRC) -I$(CLIENT_SRC)
 
 ifeq ($(CLIENT)_USE_CRYPTO),YES)
@@ -61,6 +62,11 @@ GTESTPROD_HOST += ElementTreeTest
 ElementTreeTest_SRCS += ElementTreeTest.cpp
 ElementTreeTest_LIBS += opcua
 GTESTS += ElementTreeTest
+
+GTESTPROD_HOST += StatsTest
+StatsTest_SRCS += StatsTest.cpp
+StatsTest_SRCS += Stats.cpp
+GTESTS += StatsTest
 
 #==================================================
 # Tests for different client libraries

--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -52,11 +52,6 @@ GTESTPROD_HOST += RegistryTest
 RegistryTest_SRCS += RegistryTest.cpp
 GTESTS += RegistryTest
 
-GTESTPROD_HOST += StatsTest
-StatsTest_SRCS += StatsTest.cpp
-StatsTest_LIBS += opcua
-GTESTS += StatsTest
-
 GTESTPROD_HOST += LinkParserTest
 LinkParserTest_SRCS += LinkParserTest.cpp
 LinkParserTest_LIBS += opcua

--- a/unitTestApp/src/Makefile
+++ b/unitTestApp/src/Makefile
@@ -52,6 +52,11 @@ GTESTPROD_HOST += RegistryTest
 RegistryTest_SRCS += RegistryTest.cpp
 GTESTS += RegistryTest
 
+GTESTPROD_HOST += StatsTest
+StatsTest_SRCS += StatsTest.cpp
+StatsTest_LIBS += opcua
+GTESTS += StatsTest
+
 GTESTPROD_HOST += LinkParserTest
 LinkParserTest_SRCS += LinkParserTest.cpp
 LinkParserTest_LIBS += opcua

--- a/unitTestApp/src/RegistryTest.cpp
+++ b/unitTestApp/src/RegistryTest.cpp
@@ -14,7 +14,7 @@
 #include <epicsMutex.h>
 #include <epicsGuard.h>
 
-#include "Registry.h"
+#include "DevOpcuaRegistry.h"
 
 namespace {
 

--- a/unitTestApp/src/StatsTest.cpp
+++ b/unitTestApp/src/StatsTest.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 #include "Stats.h"
 
@@ -119,8 +120,6 @@ TEST(StatsHistogramTest, ResetFix) {
     std::stringstream ss2;
     hist.print(ss2);
     // After reset, all counts should be 0.
-    // The print format is "   <=   10 us: 1"
-    // We expect "   <=   10 us: 0"
     EXPECT_EQ(ss2.str().find(": 1"), std::string::npos);
     EXPECT_NE(ss2.str().find(": 0"), std::string::npos);
 }

--- a/unitTestApp/src/StatsTest.cpp
+++ b/unitTestApp/src/StatsTest.cpp
@@ -1,0 +1,128 @@
+/*************************************************************************\
+* Copyright (c) 2025 ITER Organization.
+* This module is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "Stats.h"
+
+namespace {
+
+using namespace DevOpcua;
+
+TEST(StatsSlidingAverageTest, InitialState) {
+    StatsSlidingAverage sa(5);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 0.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 0.0);
+    EXPECT_DOUBLE_EQ(sa.getMin(), 0.0);
+    EXPECT_DOUBLE_EQ(sa.getMax(), 0.0);
+}
+
+TEST(StatsSlidingAverageTest, RecordAndAverage) {
+    StatsSlidingAverage sa(5);
+    sa.record(10.0);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 10.0);
+    sa.record(20.0);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 15.0);
+    sa.record(30.0);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 20.0);
+}
+
+TEST(StatsSlidingAverageTest, Median) {
+    StatsSlidingAverage sa(5);
+    sa.record(10.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 10.0);
+    sa.record(30.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 20.0);
+    sa.record(20.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 20.0);
+    sa.record(40.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 25.0);
+    sa.record(50.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 30.0);
+}
+
+TEST(StatsSlidingAverageTest, MinMax) {
+    StatsSlidingAverage sa(5);
+    sa.record(10.0);
+    sa.record(5.0);
+    sa.record(15.0);
+    EXPECT_DOUBLE_EQ(sa.getMin(), 5.0);
+    EXPECT_DOUBLE_EQ(sa.getMax(), 15.0);
+}
+
+TEST(StatsSlidingAverageTest, CircularBuffer) {
+    StatsSlidingAverage sa(3);
+    sa.record(10.0);
+    sa.record(20.0);
+    sa.record(30.0);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 20.0);
+
+    sa.record(40.0); // Should replace 10.0
+    // Buffer: [40, 20, 30]
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 30.0);
+    EXPECT_DOUBLE_EQ(sa.getMin(), 20.0);
+    EXPECT_DOUBLE_EQ(sa.getMax(), 40.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 30.0);
+
+    sa.record(50.0); // Should replace 20.0
+    // Buffer: [40, 50, 30]
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 40.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 40.0);
+}
+
+TEST(StatsSlidingAverageTest, Reset) {
+    StatsSlidingAverage sa(5);
+    sa.record(10.0);
+    sa.record(20.0);
+    sa.reset();
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 0.0);
+    EXPECT_DOUBLE_EQ(sa.getMedian(), 0.0);
+    sa.record(30.0);
+    EXPECT_DOUBLE_EQ(sa.getAverage(), 30.0);
+}
+
+TEST(StatsManagerTest, SlidingAverageIntegration) {
+    StatsManager &mgr = StatsManager::getInstance();
+    auto sa = mgr.getSlidingAverage("test.sa", 5);
+    ASSERT_NE(sa, nullptr);
+
+    sa->record(100.0);
+
+    std::stringstream ss;
+    mgr.report(ss, 1, "test.sa");
+    std::string report = ss.str();
+    EXPECT_NE(report.find("test.sa:"), std::string::npos);
+    EXPECT_NE(report.find("Average: 100"), std::string::npos);
+    EXPECT_NE(report.find("Median:  100"), std::string::npos);
+
+    mgr.reset("test.sa");
+    EXPECT_DOUBLE_EQ(sa->getAverage(), 0.0);
+}
+
+TEST(StatsHistogramTest, ResetFix) {
+    StatsHistogram hist({10.0, 20.0});
+    hist.record(5.0);
+    hist.record(15.0);
+    hist.record(25.0);
+
+    std::stringstream ss1;
+    hist.print(ss1);
+    EXPECT_NE(ss1.str().find(": 1"), std::string::npos);
+
+    hist.reset();
+    std::stringstream ss2;
+    hist.print(ss2);
+    // After reset, all counts should be 0.
+    // The print format is "   <=   10 us: 1"
+    // We expect "   <=   10 us: 0"
+    EXPECT_EQ(ss2.str().find(": 1"), std::string::npos);
+    EXPECT_NE(ss2.str().find(": 0"), std::string::npos);
+}
+
+} // namespace

--- a/unitTestApp/src/UaSdk/Makefile.config
+++ b/unitTestApp/src/UaSdk/Makefile.config
@@ -10,8 +10,6 @@
 
 USR_INCLUDES += $(foreach lib, $(_UASDK_MODS),-I$(UASDK)/include/$(lib))
 
-UASDK_OPCUA_OBJS += SessionUaSdk SubscriptionUaSdk ItemUaSdk
-
 # Copied from CONFIG_OPCUA - needed here for building the test executables
 
 # Debug builds need the d-marker to be set
@@ -30,14 +28,13 @@ $(foreach lib, $(UASDK_LIBS), $(eval $(lib)_DIR = $(UASDK_LIB_DIR)))
 
 GTESTPROD_HOST += RangeCheckTest
 RangeCheckTest_SRCS += RangeCheckTest.cpp
-RangeCheckTest_LIBS += $(UASDK_LIBS) $(EPICS_BASE_IOC_LIBS)
+RangeCheckTest_LIBS += opcua
 GTESTS += RangeCheckTest
 
 GTESTPROD_HOST += NamespaceMapTest
 NamespaceMapTest_SRCS += NamespaceMapTest.cpp
-NamespaceMapTest_LIBS += $(UASDK_LIBS) $(EPICS_BASE_IOC_LIBS)
-NamespaceMapTest_SYS_LIBS_Linux += $(OPCUA_SYS_LIBS_Linux)
-NamespaceMapTest_OBJS += $(OPCUA_OBJS)
+NamespaceMapTest_LIBS += opcua
+#NamespaceMapTest_SYS_LIBS_Linux += $(OPCUA_SYS_LIBS_Linux)
 GTESTS += NamespaceMapTest
 
 # Use RPATH when SDK libs are PROVIDED/EMBED/INSTALL to find indirect dependencies

--- a/unitTestApp/src/open62541/Makefile.config
+++ b/unitTestApp/src/open62541/Makefile.config
@@ -10,8 +10,6 @@
 
 USR_INCLUDES += -I$(OPEN62541)/include
 
-OPEN62541_OPCUA_OBJS += SessionOpen62541 SubscriptionOpen62541 ItemOpen62541
-
 # repeated here as the CONFIG_OPEN62541 only does it for PROVIDED
 open62541_DIR = $(OPEN62541_LIB_DIR)
 


### PR DESCRIPTION
This change introduces a new `StatsSlidingAverage` class for tracking sliding window statistics (average, median, min, max) in the OPC UA device support. It also enhances the existing statistics management system with better iocShell integration, allowing users to view detailed statistics and reset them using glob patterns. A bug in the histogram reset logic was also fixed. Comprehensive unit tests are included to ensure correctness.

---
*PR created automatically by Jules for task [15379715353886799093](https://jules.google.com/task/15379715353886799093) started by @ralphlange*