### PR TITLE
Add support for open62541 v1.4

### DIFF
--- a/.github/workflows/ci-build-open62541-linux.yml
+++ b/.github/workflows/ci-build-open62541-linux.yml
@@ -88,6 +88,20 @@ jobs:
             open62541: "1.2.10"
             name: "7.0 Ub-22 v1.2.10"
 
+          - os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+            open62541: "1.4.10"
+            name: "7.0 Ub-22 v1.4.10"
+
+          - os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            base: "3.15"
+            open62541: "1.4.10"
+            name: "3.15 Ub-22 v1.4.10"
+
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/ci-build-open62541-win.yml
+++ b/.github/workflows/ci-build-open62541-win.yml
@@ -59,6 +59,13 @@ jobs:
             open62541: "1.3.15"
             name: "7.0 Win2022 v1.3.15 VS2022 DLL"
 
+          - os: windows-2022
+            cmp: vs2022
+            configuration: default
+            base: "7.0"
+            open62541: "1.4.10"
+            name: "7.0 Win2022 v1.4.10 VS2022 DLL"
+
     steps:
     - uses: actions/checkout@v6
       with:
@@ -120,6 +127,12 @@ jobs:
             base: "7.0"
             open62541: "1.3.15"
             name: "7.0 Win2022 v1.3.15 MinGW DLL"
+
+          - os: windows-2022
+            configuration: default
+            base: "7.0"
+            open62541: "1.4.10"
+            name: "7.0 Win2022 v1.4.10 MinGW DLL"
 
     steps:
     - uses: msys2/setup-msys2@v2

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ There are two choices for the low-level OPC UA client library:
 ### Using the open62541 SDK
 
 * The [open62541 SDK][open62541.sdk] \
-  Choose a recent release from series 1.2 or 1.3
-  (release seriens 1.4 is not supported yet).
+  Choose a recent release from series 1.2, 1.3 or 1.4.
   Download the sources using GitHub releases, not through the project website.
 
 * For OPC UA security support (authentication/encryption), you need

--- a/devOpcuaSup/open62541/README.md
+++ b/devOpcuaSup/open62541/README.md
@@ -15,8 +15,7 @@ Please contact the authors
 ## Prerequisites
 
 *   [Open62541](https://www.open62541.org/) SDK / C library
-    (v1.2 and v1.3 series have been tested; their system packages should also work.
-    open62541 v1.4 changed the header file structure and does not work yet.)
+    (v1.2, v1.3 and v1.4 series have been tested; their system packages should also work.)
     
 *   Cmake (3.x) if you're building Open62541 from sources.
 

--- a/devOpcuaSup/open62541/SessionOpen62541.cpp
+++ b/devOpcuaSup/open62541/SessionOpen62541.cpp
@@ -411,9 +411,22 @@ SessionOpen62541::setOption (const std::string &name, const std::string &value)
             // Loglevels:  0:trace, 1:debug, 2:info, 3:warning, 4:error, 5:fatal (and higher)
             // Our debug=0 shall only print fatal errors.
             // After that, the higher debug the lower UA_LogLevel, down to 0.
+#if UA_OPEN62541_VER_MAJOR*100+UA_OPEN62541_VER_MINOR >= 104
+            if (config->logging && config->logging->clear)
+                config->logging->clear(config->logging);
+            {
+                UA_Logger *newLogger = (UA_Logger *)UA_malloc(sizeof(UA_Logger));
+                if (newLogger) {
+                    *newLogger = UA_Log_Stdout_withLevel(static_cast<UA_LogLevel>(std::max(0, 5-debug)));
+                    newLogger->clear = [](UA_Logger *l){ UA_free(l); };
+                    config->logging = newLogger;
+                }
+            }
+#else
             if (config->logger.clear)
                 config->logger.clear(config->logger.context); // Use context as opaque handle only!
             config->logger = UA_Log_Stdout_withLevel(static_cast<UA_LogLevel>(std::max(0, 5-debug)));
+#endif
         }
     } else if (name == "batch-nodes") {
         errlogPrintf("DEPRECATED: option 'batch-nodes'; use 'nodes-max' instead\n");
@@ -503,9 +516,22 @@ SessionOpen62541::connect (bool manual)
     }
     UA_ClientConfig *config = UA_Client_getConfig(client);
     if (debug < 5) {
+#if UA_OPEN62541_VER_MAJOR*100+UA_OPEN62541_VER_MINOR >= 104
+        if (config->logging && config->logging->clear)
+            config->logging->clear(config->logging);
+        {
+            UA_Logger *newLogger = (UA_Logger *)UA_malloc(sizeof(UA_Logger));
+            if (newLogger) {
+                *newLogger = UA_Log_Stdout_withLevel(static_cast<UA_LogLevel>(std::max(0, 5-debug)));
+                newLogger->clear = [](UA_Logger *l){ UA_free(l); };
+                config->logging = newLogger;
+            }
+        }
+#else
         if (config->logger.clear)
             config->logger.clear(config->logger.context);
         config->logger = UA_Log_Stdout_withLevel(static_cast<UA_LogLevel>(std::max(0, 5-debug)));
+#endif
     }
 #ifdef HAS_SECURITY
     // We need the client certificate before UA_ClientConfig_setDefaultEncryption


### PR DESCRIPTION
## What changed

open62541 v1.4 renamed `UA_ClientConfig.logger` (an embedded `UA_Logger` struct) to `UA_ClientConfig.logging` (a `UA_Logger *` pointer). The existing code assigned to `config->logger` in two places and failed to compile against v1.4 headers.

### `devOpcuaSup/open62541/SessionOpen62541.cpp`

Both logger-setup blocks are wrapped with a version guard:

`c
#if UA_OPEN62541_VER_MAJOR*100+UA_OPEN62541_VER_MINOR >= 104
    // v1.4+: logging is UA_Logger* - allocate on heap, set clear to UA_free
    config->logging = newLogger;
#else
    // v1.3 and earlier: logger is an embedded UA_Logger struct
    config->logger = UA_Log_Stdout_withLevel(...);
#endif
`

For v1.4+, the logger is heap-allocated via `UA_malloc` with a `clear` callback that calls `UA_free`, so `UA_ClientConfig_clear` (invoked by `UA_Client_delete`) can reclaim it properly.  The capture-less lambda `[](UA_Logger *l){ UA_free(l); }` decays to a plain function pointer under C++11.

No other v1.4 breaking changes affect this codebase:
- The `UA_BUILTIN_TYPES_COUNT` / `UA_DATATYPES_USE_POINTER` guard still works correctly in v1.4.
- `UA_CertificateVerification_CertFolders`'s optional 4th parameter (added in v1.4) is gated on `UA_ENABLE_CERT_REJECTED_DIR`, which is not enabled in the CI build, so the three-argument call compiles unchanged.
- The new `UA_SecureChannelState` enum values were already guarded with `>= 104` in a previous commit.

### CI workflows

New `open62541: "1.4.10"` matrix entries added to:
- **Linux**: Base 7.0 + 3.15 on ubuntu-22.04
- **Windows**: VS2022 DLL and MinGW DLL on windows-2022

### README

Both `README.md` and `devOpcuaSup/open62541/README.md` updated - the "v1.4 is not supported yet" note replaced with "v1.2, v1.3 and v1.4 series have been tested".